### PR TITLE
Link React frontend to Flask backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ installed with `pip install python-docx reportlab`.
 
 
 
-## Backend Table Service
+## Backend API
 
-A placeholder backend service under `backend/` will expose table data to the React frontend. See [docs/backend_table_service_tasks.md](docs/backend_table_service_tasks.md) for the planned tasks.
+The Flask backend under `flask_backend/` exposes REST endpoints that the React frontend fetches. Docker Compose runs a `backend` service alongside the `web` frontend service. The frontend reads the API base URL from the `VITE_API_URL` environment variable.
+
+See [docs/separation_of_duties.md](docs/separation_of_duties.md) for details on the responsibilities of each component.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,22 @@ services:
     ports:
       - "3306:3306"
 
+  backend:
+    build: ./flask_backend
+    environment:
+      - DB_HOST=mariadb
+      - DB_USER=${DB_USER:-root}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_NAME=${DB_NAME:-mci}
+    depends_on:
+      - mariadb
+    ports:
+      - "3001:3000"
+
   web:
     build: ./frontend
     environment:
-      - VITE_API_URL=http://localhost
+      - VITE_API_URL=http://backend:3000
     ports:
       - "3000:3000"
 

--- a/docs/separation_of_duties.md
+++ b/docs/separation_of_duties.md
@@ -1,0 +1,9 @@
+# Separation of Duties
+
+The project is split into a React frontend and a Flask backend. The backend exposes REST endpoints which the frontend fetches to display data.
+
+- **Backend (`flask_backend/`)** – Provides an API for retrieving table data from the database. The backend is responsible for applying authentication and preparing JSON responses consumed by the UI.
+- **Frontend (`frontend/`)** – React application that renders the user interface. It communicates with the backend via `VITE_API_URL` and displays the data returned by the API.
+
+The backend does not render HTML templates. Instead, it returns JSON that the frontend uses to build views on each page.
+

--- a/flask_backend/Dockerfile
+++ b/flask_backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "flask_backend.app"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the Flask backend
- expose the new `backend` service in `docker-compose.yml` and point the frontend to it
- document the separation of duties between frontend and backend
- update README with info about the backend API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68748cdcb5248326aa785201b9af3326