### PR TITLE
Add events that need packets view

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -47,6 +47,17 @@ def get_table(name):
         print(exc)
         return jsonify({'error': 'Failed to fetch table data'}), 500
 
+
+@app.route('/api/events/need_packets')
+@requires_auth
+def events_need_packets():
+    try:
+        rows = table_service.get_events_need_packets()
+        return jsonify({'data': rows})
+    except Exception as exc:
+        print(exc)
+        return jsonify({'error': 'Failed to fetch table data'}), 500
+
 if __name__ == '__main__':
     port = int(os.getenv('PORT', '3000'))
     app.run(host='0.0.0.0', port=port)

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -35,3 +35,23 @@ def get_table_data(name: str):
     cursor.close()
     conn.close()
     return rows
+
+
+def get_events_need_packets():
+    """Return up to 100 events that still require packet uploads."""
+    conn = get_pool().get_connection()
+    cursor = conn.cursor(dictionary=True)
+    query = (
+        "SELECT e.id AS `ID`, e.patient_id AS `Patient ID`, "
+        "e.event_date AS `Date`, "
+        "GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS `Criteria` "
+        "FROM events e "
+        "JOIN criterias c ON e.id = c.event_id "
+        "WHERE e.status = 'created' "
+        "GROUP BY e.id LIMIT 100"
+    )
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return rows

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -10,6 +10,15 @@ def test_get_table_route(mock_service):
     assert res.get_json() == {'data': [{'id': 1}]}
 
 
+@patch('flask_backend.table_service.get_events_need_packets')
+def test_get_need_packets_route(mock_service):
+    mock_service.return_value = [{'ID': 1}]
+    client = app.test_client()
+    res = client.get('/api/events/need_packets')
+    assert res.status_code == 200
+    assert res.get_json() == {'data': [{'ID': 1}]}
+
+
 @patch("flask_backend.table_service.get_table_data")
 def test_auth_required(mock_service):
     mock_service.return_value = []
@@ -18,4 +27,15 @@ def test_auth_required(mock_service):
     app_mod.keycloak_openid = object()
     client = app_mod.app.test_client()
     res = client.get('/api/tables/events')
+    assert res.status_code == 401
+
+
+@patch('flask_backend.table_service.get_events_need_packets')
+def test_auth_required_need_packets(mock_service):
+    mock_service.return_value = []
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = object()
+    client = app_mod.app.test_client()
+    res = client.get('/api/events/need_packets')
     assert res.status_code == 401

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -15,3 +15,18 @@ def test_get_table_data(mock_get_pool):
     mock_get_pool.assert_called()
     mock_cursor.execute.assert_called_with('SELECT * FROM `events` LIMIT 100')
     assert rows == [{'id': 1}]
+
+
+@patch('flask_backend.table_service.get_pool')
+def test_get_events_need_packets(mock_get_pool):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [{'ID': 1}]
+    mock_conn.cursor.return_value = mock_cursor
+    mock_get_pool.return_value.get_connection.return_value = mock_conn
+
+    rows = ts.get_events_need_packets()
+
+    mock_get_pool.assert_called()
+    assert "GROUP BY e.id" in mock_cursor.execute.call_args.args[0]
+    assert rows == [{'ID': 1}]

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -29,6 +29,7 @@ function Table({ rows }) {
 
 function Home() {
   const [rows, setRows] = useState([])
+  const [needPacketRows, setNeedPacketRows] = useState([])
   const [search, setSearch] = useState('')
 
   useEffect(() => {
@@ -36,9 +37,20 @@ function Home() {
       .then((res) => res.json())
       .then((json) => setRows(json.data || []))
       .catch(() => {})
+
+    fetch('/api/events/need_packets')
+      .then((res) => res.json())
+      .then((json) => setNeedPacketRows(json.data || []))
+      .catch(() => {})
   }, [])
 
   const filteredRows = rows.filter((row) =>
+    Object.values(row).some((v) =>
+      String(v).toLowerCase().includes(search.toLowerCase())
+    )
+  )
+
+  const filteredNeedPacketRows = needPacketRows.filter((row) =>
     Object.values(row).some((v) =>
       String(v).toLowerCase().includes(search.toLowerCase())
     )
@@ -102,6 +114,11 @@ function Home() {
       <section>
         <h3>Table Preview</h3>
         <Table rows={filteredRows} />
+      </section>
+
+      <section>
+        <h3>Events That Need Packets</h3>
+        <Table rows={filteredNeedPacketRows} />
       </section>
 
       <div className="sections-grid">


### PR DESCRIPTION
## Summary
- support retrieving events that need packets from the backend
- show events that need packets on the home page
- test new API route and service query

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749fd4a86483269ff4f9412ea46c0f