### PR TITLE
Update README and envs for frontend-backend link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,6 @@ DB_ROOT_PASSWORD=example_root_password
 DB_NAME=mci_db
 DB_USER=mci_user
 DB_PASSWORD=mci_pass
+# Base URL for the backend API used by the React frontend
+VITE_API_URL=http://localhost:3001
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TODO:
         Verify that .htaccess has no explicitly allowed users ( what is the default ? )
 
 
-DOCKER MARIADB:
+DOCKER DATABASE:
 
         cp .env.example .env
         docker-compose up -d mariadb
@@ -45,21 +45,32 @@ This repository includes a lightweight Docker configuration based on the setup u
 
 ### Build and Run
 
-```bash
-# build the container
-docker-compose build
+1. Copy `.env.example` to `.env` and edit if necessary. `VITE_API_URL` should
+   point at the backend API (defaults to `http://localhost:3001`).
+2. Build the Docker images:
 
-# start the container on http://localhost:8080
-docker-compose up
-```
+   ```bash
+   docker-compose build
+   ```
+
+3. Start the stack:
+
+   ```bash
+   docker-compose up
+   ```
+
+   The frontend will be served on <http://localhost:3000/> and the backend API
+   on <http://localhost:3001/>.
 
 ### Environment Variables
 
-Runtime configuration is provided via `default.env` which is loaded by `docker-compose`. The following variables are available:
+Runtime configuration is provided via `.env` which is loaded automatically by
+`docker-compose`. The following variables are available:
 
 - `FHIR_SERVER` – URL of the FHIR server used by the application.
+- `VITE_API_URL` – base URL of the backend API consumed by the React frontend.
 
-You may override these values by creating your own `.env` or editing `default.env`.
+You may override these values by editing your `.env` file.
 
 ## Local Development
 

--- a/default.env
+++ b/default.env
@@ -1,3 +1,5 @@
 # Default environment variables for mci container
 # URL to FHIR server used by the application
 FHIR_SERVER=http://example-fhir-server.com
+# Base URL for the backend API used by the React frontend
+VITE_API_URL=http://localhost:3001

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,10 @@
+# Development Quick Start
+
+These steps start the frontend and backend using Docker Compose.
+
+1. Copy `.env.example` to `.env`.
+2. Run `docker-compose up --build` to build images and start containers.
+3. Open <http://localhost:3000/> in your browser. The backend API will be
+   available at <http://localhost:3001/>.
+
+You can stop the containers with `Ctrl+C` or by running `docker-compose down`.

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,6 +2,11 @@ import { Link } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import './Home.css'
 
+// Base URL for the backend API. When running under Docker Compose the
+// environment variable is provided by the compose file. Fallback to a
+// relative path so the frontend can be served without configuration.
+const API_BASE = import.meta.env.VITE_API_URL || ''
+
 function Table({ rows }) {
   if (!rows.length) return <p>No data found.</p>
   const headers = Object.keys(rows[0])
@@ -33,12 +38,12 @@ function Home() {
   const [search, setSearch] = useState('')
 
   useEffect(() => {
-    fetch('/api/tables/events')
+    fetch(`${API_BASE}/api/tables/events`)
       .then((res) => res.json())
       .then((json) => setRows(json.data || []))
       .catch(() => {})
 
-    fetch('/api/events/need_packets')
+    fetch(`${API_BASE}/api/events/need_packets`)
       .then((res) => res.json())
       .then((json) => setNeedPacketRows(json.data || []))
       .catch(() => {})


### PR DESCRIPTION
## Summary
- improve startup directions
- show new backend API URL env var
- reference new development guide
- inject base API URL into React app
- document environment variable defaults

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687512f8c94883269952887da475df1d