### PR TITLE
Add .env example and document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,6 @@ DB_USER=mci_user
 DB_PASSWORD=mci_pass
 # Base URL for the backend API used by the React frontend
 VITE_API_URL=http://localhost:3001
+# URL to FHIR server used by the application
+FHIR_SERVER=http://example-fhir-server.com
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ app/tmp/*
 frontend/node_modules/*
 frontend/dist
 backend/node_modules/*
+.env

--- a/README.md
+++ b/README.md
@@ -64,13 +64,18 @@ This repository includes a lightweight Docker configuration based on the setup u
 
 ### Environment Variables
 
-Runtime configuration is provided via `.env` which is loaded automatically by
-`docker-compose`. The following variables are available:
+Runtime configuration is provided via a `.env` file that you create by
+copying `.env.example`. Docker Compose automatically loads this file when the
+containers are started. The template defines the following variables:
 
-- `FHIR_SERVER` – URL of the FHIR server used by the application.
+- `DB_ROOT_PASSWORD` – password for the MariaDB root user.
+- `DB_NAME` – name of the application's database.
+- `DB_USER` – database user for the application.
+- `DB_PASSWORD` – password for `DB_USER`.
 - `VITE_API_URL` – base URL of the backend API consumed by the React frontend.
+- `FHIR_SERVER` – URL of the FHIR server used by the application.
 
-You may override these values by editing your `.env` file.
+Override these values in your copied `.env` file as needed.
 
 ## Local Development
 


### PR DESCRIPTION
## Summary
- extend `.env.example` with placeholder variables for FHIR server
- document all environment variables in README
- ignore local `.env` files in git

## Testing
- `pytest -q`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687519dcc3108326badb12515318bf5c