### PR TITLE
Move cnics.sql to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ DATABASE INITIALIZATION:
         # Core schema
         mysql -u$DB_USER -p$DB_PASSWORD $DB_NAME < app/config/sql/sessions.sql
         # Additional schemas are under app/config/sql/
+        # Sample CNICS dataset
+        mysql -u$DB_USER -p$DB_PASSWORD $DB_NAME < flask_backend/cnics.sql
         # Test dataset
         mysql $DB_NAME < app/tests/cnics-mci_test.test_event_derived_datas.schema.sql
 ## Container Setup

--- a/flask_backend/README.md
+++ b/flask_backend/README.md
@@ -21,3 +21,6 @@ The API exposes `/api/tables/<name>` which returns up to 100 rows from the speci
 If the environment variable `KEYCLOAK_REALM` is set, requests are validated
 against a Keycloak server. Configure `KEYCLOAK_URL`, `KEYCLOAK_CLIENT_ID` and
 `KEYCLOAK_CLIENT_SECRET` accordingly.
+
+A sample CNICS database dump `cnics.sql` is provided in this directory for local
+testing. Load it into your MariaDB instance after creating the schema.


### PR DESCRIPTION
## Summary
- move the cnics dump into the flask backend
- document the new location in README files

## Testing
- `pip install -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751fac042483268e9d0d13edbf8dc9