### PR TITLE
Add pagination to table preview

### DIFF
--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -45,3 +45,11 @@
   font-weight: bold;
   margin-bottom: 0.5rem;
 }
+
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1em;
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -8,27 +8,52 @@ import './Home.css'
 const API_BASE = import.meta.env.VITE_API_URL || ''
 
 function Table({ rows }) {
+  const [page, setPage] = useState(1)
+  const pageSize = 20
+
   if (!rows.length) return <p>No data found.</p>
+
+  const totalPages = Math.ceil(rows.length / pageSize)
   const headers = Object.keys(rows[0])
+  const pageRows = rows.slice((page - 1) * pageSize, page * pageSize)
+
+  const goPrev = () => setPage(p => Math.max(1, p - 1))
+  const goNext = () => setPage(p => Math.min(totalPages, p + 1))
+
   return (
-    <table className="data-table">
-      <thead>
-        <tr>
-          {headers.map(h => (
-            <th key={h}>{h}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, idx) => (
-          <tr key={idx}>
+    <>
+      <table className="data-table">
+        <thead>
+          <tr>
             {headers.map(h => (
-              <td key={h}>{row[h]}</td>
+              <th key={h}>{h}</th>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {pageRows.map((row, idx) => (
+            <tr key={idx}>
+              {headers.map(h => (
+                <td key={h}>{row[h]}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div className="pagination">
+          <button onClick={goPrev} disabled={page === 1}>
+            Previous
+          </button>
+          <span>
+            Page {page} of {totalPages}
+          </span>
+          <button onClick={goNext} disabled={page === totalPages}>
+            Next
+          </button>
+        </div>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- add client-side table pagination for Table Preview and Events That Need Packets
- style new pagination control

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687520287508832687474c8ed14993f1