### PR TITLE
Link docker compose with .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository includes a lightweight Docker configuration based on the setup u
 
 Runtime configuration is provided via a `.env` file that you create by
 copying `.env.example`. Docker Compose automatically loads this file when the
-containers are started. The template defines the following variables:
+services are built or started. The template defines the following variables:
 
 - `DB_ROOT_PASSWORD` – password for the MariaDB root user.
 - `DB_NAME` – name of the application's database.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KEYCLOAK_IMPORT: ${KEYCLOAK_IMPORT:-/opt/keycloak/data/import/example-realm.json}
+    env_file:
+      - .env
     ports:
       - "8080:8080"
     volumes:
@@ -21,6 +23,8 @@ services:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+    env_file:
+      - .env
     volumes:
       - db_data:/var/lib/mysql
     ports:
@@ -33,6 +37,8 @@ services:
       - DB_USER=${DB_USER:-root}
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_NAME=${DB_NAME:-mci}
+    env_file:
+      - .env
     depends_on:
       - mariadb
     ports:
@@ -42,6 +48,8 @@ services:
     build: ./frontend
     environment:
       - VITE_API_URL=http://backend:3000
+    env_file:
+      - .env
     ports:
       - "3000:3000"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 These steps start the frontend and backend using Docker Compose.
 
 1. Copy `.env.example` to `.env`.
-2. Run `docker-compose up --build` to build images and start containers.
+2. Docker Compose reads variables from `.env` automatically. Run `docker-compose up --build` to build images and start containers.
 3. Open <http://localhost:3000/> in your browser. The backend API will be
    available at <http://localhost:3001/>.
 


### PR DESCRIPTION
## Summary
- load environment vars from .env when building services
- document that docker compose reads .env automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687527159b30832697b9d317b849eb74