### PR TITLE
Fix menu orientation and close on outside click

### DIFF
--- a/frontend/src/components/MenuBar.css
+++ b/frontend/src/components/MenuBar.css
@@ -1,4 +1,4 @@
-.menu-bar ul {
+.menu-bar > ul {
   display: flex;
   gap: 1rem;
   list-style: none;
@@ -17,4 +17,5 @@
   background: #f8f8f8;
   border: 1px solid #ccc;
   border-radius: 4px;
+  display: block;
 }

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -1,9 +1,24 @@
 import { Link } from 'react-router-dom'
+import { useEffect, useRef } from 'react'
 import './MenuBar.css'
 
 function MenuBar({ admin, uploader, reviewer }) {
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    function handleClick(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        menuRef.current
+          .querySelectorAll('details[open]')
+          .forEach((detail) => detail.removeAttribute('open'))
+      }
+    }
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [])
+
   return (
-    <nav className="menu-bar">
+    <nav className="menu-bar" ref={menuRef}>
       <ul>
         {admin && (
           <li>


### PR DESCRIPTION
## Summary
- fix dropdown layout orientation so nested links stack vertically
- close open dropdowns when clicking outside of the menu

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68752e96b6a08326a99d2029f4770bd5