### PR TITLE
Add backend view creation utility

### DIFF
--- a/flask_backend/create_views.py
+++ b/flask_backend/create_views.py
@@ -1,0 +1,35 @@
+import os
+from mysql import connector
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_CONFIG = {
+    'host': os.getenv('DB_HOST', 'localhost'),
+    'user': os.getenv('DB_USER', 'root'),
+    'password': os.getenv('DB_PASSWORD', ''),
+    'database': os.getenv('DB_NAME', 'mci'),
+}
+
+
+def create_views():
+    """Create database views used by the frontend."""
+    conn = connector.connect(**DB_CONFIG)
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        CREATE OR REPLACE VIEW events_view AS
+        SELECT e.*, p.site_patient_id, p.site
+        FROM events e
+        JOIN uw_patients p ON e.patient_id = p.id
+        """
+    )
+
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    create_views()

--- a/flask_backend/tests/test_create_views.py
+++ b/flask_backend/tests/test_create_views.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock, patch
+import flask_backend.create_views as cv
+
+@patch('flask_backend.create_views.connector.connect')
+def test_create_views(mock_connect):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_connect.return_value = mock_conn
+
+    cv.create_views()
+
+    mock_connect.assert_called()
+    assert "CREATE OR REPLACE VIEW" in mock_cursor.execute.call_args.args[0]
+    assert "JOIN uw_patients" in mock_cursor.execute.call_args.args[0]
+    mock_conn.commit.assert_called()


### PR DESCRIPTION
## Summary
- provide a script under `flask_backend` for generating database views
- add tests for view creation logic

## Testing
- `pip install -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768ece6ab8832685c7ce284d61b548