### PR TITLE
Use events_view in frontend

### DIFF
--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 def test_get_table_route(mock_service):
     mock_service.return_value = [{'id': 1}]
     client = app.test_client()
-    res = client.get('/api/tables/events')
+    res = client.get('/api/tables/events_view')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'id': 1}]}
 
@@ -26,7 +26,7 @@ def test_auth_required(mock_service):
     app_mod = importlib.import_module('flask_backend.app')
     app_mod.keycloak_openid = object()
     client = app_mod.app.test_client()
-    res = client.get('/api/tables/events')
+    res = client.get('/api/tables/events_view')
     assert res.status_code == 401
 
 

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -10,10 +10,10 @@ def test_get_table_data(mock_get_pool):
     mock_conn.cursor.return_value = mock_cursor
     mock_get_pool.return_value.get_connection.return_value = mock_conn
 
-    rows = ts.get_table_data('events')
+    rows = ts.get_table_data('events_view')
 
     mock_get_pool.assert_called()
-    mock_cursor.execute.assert_called_with('SELECT * FROM `events` LIMIT 100')
+    mock_cursor.execute.assert_called_with('SELECT * FROM `events_view` LIMIT 100')
     assert rows == [{'id': 1}]
 
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -63,7 +63,8 @@ function Home() {
   const [search, setSearch] = useState('')
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/tables/events`)
+    // Use the events_view provided by the backend instead of the raw table
+    fetch(`${API_BASE}/api/tables/events_view`)
       .then((res) => res.json())
       .then((json) => setRows(json.data || []))
       .catch(() => {})


### PR DESCRIPTION
## Summary
- reference `events_view` instead of `events` in the Home page
- update tests to match the new view name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876909fcb04832686fd9fcbcb8e01d3