### PR TITLE
Automate creation of events_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ DOCKER DATABASE:
 
         cp .env.example .env
         docker-compose up -d mariadb
+        # Initialization scripts load `cnics.sql` and create the `events_view` view
 
 ## Container Setup
 

--- a/flask_backend/README.md
+++ b/flask_backend/README.md
@@ -23,4 +23,6 @@ against a Keycloak server. Configure `KEYCLOAK_URL`, `KEYCLOAK_CLIENT_ID` and
 `KEYCLOAK_CLIENT_SECRET` accordingly.
 
 A sample CNICS database dump `cnics.sql` is provided in this directory for local
-testing. Load it into your MariaDB instance after creating the schema.
+testing. Load it into your MariaDB instance after creating the schema. The
+Docker initialization scripts also create views such as `events_view` so the
+frontend can query the API immediately.

--- a/init/04-create-views.sql
+++ b/init/04-create-views.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE VIEW events_view AS
+SELECT e.*, p.site_patient_id, p.site
+FROM events e
+JOIN uw_patients p ON e.patient_id = p.id;
+


### PR DESCRIPTION
## Summary
- create new init script `init/04-create-views.sql`
- document automatic view creation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a0930bc4832682b2c87e876aaac2