### PR TITLE
Align packet query with patient view

### DIFF
--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -47,6 +47,7 @@ def get_events_need_packets():
         "GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS `Criteria` "
         "FROM events e "
         "JOIN criterias c ON e.id = c.event_id "
+        "JOIN patients p ON e.patient_id = p.id "
         "WHERE e.status = 'created' "
         "GROUP BY e.id LIMIT 100"
     )

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -28,5 +28,7 @@ def test_get_events_need_packets(mock_get_pool):
     rows = ts.get_events_need_packets()
 
     mock_get_pool.assert_called()
-    assert "GROUP BY e.id" in mock_cursor.execute.call_args.args[0]
+    query = mock_cursor.execute.call_args.args[0]
+    assert "GROUP BY e.id" in query
+    assert ("JOIN patients" in query) or ("JOIN uw_patients2" in query)
     assert rows == [{'ID': 1}]


### PR DESCRIPTION
## Summary
- join `patients` view in `get_events_need_packets`
- check for patient join in tests

## Testing
- `pip install -q -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a3246cf48326bd6a1c15818bf501