### PR TITLE
Move instructions below tables for easier access

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -92,6 +92,27 @@ function Home() {
       <h1>CNICS Validation</h1>
       <p>Welcome to the CNICS Validation application.</p>
 
+      <section>
+        <h3>Quick Search</h3>
+        <input
+          className="quick-search"
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search"
+        />
+      </section>
+
+      <section>
+        <h3>Table Preview</h3>
+        <Table rows={filteredRows} />
+      </section>
+
+      <section>
+        <h3>Events That Need Packets</h3>
+        <Table rows={filteredNeedPacketRows} />
+      </section>
+
       <div className="infobox">
         <h3>Review packets should contain:</h3>
         <ol>
@@ -164,27 +185,6 @@ function Home() {
           </li>
         </ul>
       </div>
-
-      <section>
-        <h3>Quick Search</h3>
-        <input
-          className="quick-search"
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search"
-        />
-      </section>
-
-      <section>
-        <h3>Table Preview</h3>
-        <Table rows={filteredRows} />
-      </section>
-
-      <section>
-        <h3>Events That Need Packets</h3>
-        <Table rows={filteredNeedPacketRows} />
-      </section>
 
       {/* Dropdown menus are now available in the top navigation */}
     </div>


### PR DESCRIPTION
## Summary
- rearrange Home page so instruction documents follow the data tables

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a758a38c8326beb21f639f8d0bf9