### PR TITLE
Add VITE_API_URL build arg

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,9 +30,12 @@ services:
       - internal
 
   web:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        VITE_API_URL: ${VITE_API_URL}
     environment:
-      VITE_API_URL: http://localhost:3001
+      VITE_API_URL: ${VITE_API_URL}
     depends_on:
       - backend
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,8 @@ COPY package.json package-lock.json* ./
 RUN npm install --production=false \
     && chmod +x node_modules/.bin/vite
 COPY . .
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build
 
 FROM node:20-alpine


### PR DESCRIPTION
## Summary
- expose `VITE_API_URL` in `frontend/Dockerfile`
- configure compose file to pass build args and environment

## Testing
- `docker-compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a938eaec83269d4252f93f533de5