### PR TITLE
Add event status summary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ running `python generate_pdfs.py` from the project root.
 The Flask backend under `flask_backend/` exposes REST endpoints that the React frontend fetches. Docker Compose runs a `backend` service alongside the `web` frontend service. The frontend reads the API base URL from the `VITE_API_URL` environment variable.
 
 See [docs/separation_of_duties.md](docs/separation_of_duties.md) for details on the responsibilities of each component.
+
+### Available Endpoints
+
+- `/api/tables/<name>` – return rows from a database table or view.
+- `/api/events/need_packets` – events awaiting packet uploads.
+- `/api/events/for_review` – events with packets ready for review.
+- `/api/events/status_summary` – counts of events grouped by status.

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -103,6 +103,17 @@ def events_for_review():
         return jsonify({'error': 'Failed to fetch table data'}), 500
 
 
+@app.route('/api/events/status_summary')
+@requires_auth
+def events_status_summary():
+    try:
+        summary = table_service.get_event_status_summary()
+        return jsonify({'data': summary})
+    except Exception as exc:
+        print(exc)
+        return jsonify({'error': 'Failed to fetch table data'}), 500
+
+
 @app.route('/files/<path:filename>')
 def get_file(filename: str):
     file_path = os.path.join(FILES_DIR, filename)

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -77,3 +77,14 @@ def get_events_for_review():
     cursor.close()
     conn.close()
     return rows
+
+
+def get_event_status_summary():
+    """Return a mapping of event status names to row counts."""
+    conn = get_pool().get_connection()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute("SELECT status, COUNT(*) AS count FROM events GROUP BY status")
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return {row["status"]: row["count"] for row in rows}

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -62,3 +62,26 @@ def test_auth_required_for_review(mock_service):
     client = app_mod.app.test_client()
     res = client.get('/api/events/for_review')
     assert res.status_code == 401
+
+
+@patch('flask_backend.table_service.get_event_status_summary')
+def test_status_summary_route(mock_service):
+    mock_service.return_value = {'uploaded': 5}
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = None
+    client = app_mod.app.test_client()
+    res = client.get('/api/events/status_summary')
+    assert res.status_code == 200
+    assert res.get_json() == {'data': {'uploaded': 5}}
+
+
+@patch('flask_backend.table_service.get_event_status_summary')
+def test_auth_required_status_summary(mock_service):
+    mock_service.return_value = {}
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = object()
+    client = app_mod.app.test_client()
+    res = client.get('/api/events/status_summary')
+    assert res.status_code == 401

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -49,3 +49,18 @@ def test_get_events_for_review(mock_get_pool):
     assert "WHERE e.status = 'uploaded'" in query
     assert "GROUP BY e.id" in query
     assert rows == [{'ID': 2}]
+
+
+@patch('flask_backend.table_service.get_pool')
+def test_get_event_status_summary(mock_get_pool):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [{'status': 'created', 'count': 3}]
+    mock_conn.cursor.return_value = mock_cursor
+    mock_get_pool.return_value.get_connection.return_value = mock_conn
+
+    summary = ts.get_event_status_summary()
+
+    mock_get_pool.assert_called()
+    mock_cursor.execute.assert_called()
+    assert summary == {'created': 3}


### PR DESCRIPTION
## Summary
- provide a new `/api/events/status_summary` endpoint
- implement database helper for event status counts
- document available backend endpoints
- test new service and route

## Testing
- `pip install -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876af34f3188326a1dc88498d47d626