### PR TITLE
Fix CORS headers for Flask backend

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -42,8 +42,6 @@ def ensure_pdf(doc_path: str, pdf_path: str) -> None:
             y = height - 40
     c.save()
 
-app = Flask(__name__)
-
 # Optional Keycloak configuration mirroring the Express backend
 keycloak_openid = None
 if os.getenv("KEYCLOAK_REALM"):


### PR DESCRIPTION
## Summary
- fix double `Flask` instantiation so `flask-cors` attaches properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788b8ba0d88326854399d95d1ae8c4