### PR TITLE
Fix static files path for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,6 @@ DB_PASSWORD=mci_pass
 VITE_API_URL=http://localhost:3001
 # URL to FHIR server used by the application
 FHIR_SERVER=http://example-fhir-server.com
+# Directory containing instruction files to serve via the backend
+FILES_DIR=./app/webroot/files
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ This repository includes a lightweight Docker configuration based on the setup u
 3. Start the stack:
 
    ```bash
-   docker-compose up
-   ```
+    docker-compose up
+    ```
 
-   The frontend will be served on <http://localhost:3000/> and the backend API
-   on <http://localhost:3001/>.
+    The frontend will be served on <http://localhost:3000/> and the backend API
+    on <http://localhost:3001/>.
+    The compose file mounts `app/webroot/files` into the backend container so
+    instruction documents are available at `/files/<name>`.
 
 ### Environment Variables
 
@@ -45,6 +47,7 @@ services are built or started. The template defines the following variables:
 - `DB_PASSWORD` – password for `DB_USER`.
 - `VITE_API_URL` – base URL of the backend API consumed by the React frontend.
 - `FHIR_SERVER` – URL of the FHIR server used by the application.
+- `FILES_DIR` – directory containing instruction files served by the backend.
 
 Override these values in your copied `.env` file as needed.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
+      FILES_DIR: /files
       PORT: 3000
     depends_on:
       - mariadb
@@ -28,6 +29,8 @@ services:
       - "3001:3000"
     networks:
       - internal
+    volumes:
+      - ${FILES_DIR:-./app/webroot/files}:/files:ro
 
   web:
     build:

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -18,7 +18,14 @@ CORS(
 
 load_dotenv()
 
-FILES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app', 'webroot', 'files'))
+# Directory containing static instruction files. When running in Docker the
+# path can be overridden with the ``FILES_DIR`` environment variable so the
+# backend can access files from outside its build context.
+FILES_DIR = os.getenv("FILES_DIR")
+if not FILES_DIR:
+    FILES_DIR = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "app", "webroot", "files")
+    )
 os.makedirs(FILES_DIR, exist_ok=True)
 
 

--- a/generate_pdfs.py
+++ b/generate_pdfs.py
@@ -3,7 +3,7 @@ from docx import Document
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
 
-FILES_DIR = 'app/webroot/files'
+FILES_DIR = os.getenv('FILES_DIR', 'app/webroot/files')
 
 for fname in os.listdir(FILES_DIR):
     if fname.lower().endswith('.doc'):


### PR DESCRIPTION
## Summary
- read instruction file path from optional `FILES_DIR` environment variable
- mount docs directory to backend container
- document `FILES_DIR` usage and default volume mapping
- allow PDF generation script to honor `FILES_DIR`

## Testing
- `pip install -q -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792b3c85f08326b4b482e928847912