### PR TITLE
Document PDF generation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ See [docs/development.md](docs/development.md) for instructions on running the a
 ## Generating PDF copies of instruction files
 
 Some pages link to `.pdf` versions of the documents under `app/webroot/files/`.
-If a requested PDF does not exist the Flask backend will generate it on demand
-using `python-docx` and `reportlab`. You can also pre-create the PDFs locally by
-running `python generate_pdfs.py` from the project root.
+When running via Docker Compose this directory is mounted read-only, so the
+backend cannot create PDF files on the fly. Run `python generate_pdfs.py` from
+the project root **before** starting the containers to generate the PDF copies
+locally.
 
 
 


### PR DESCRIPTION
## Summary
- explain that the files directory is mounted read-only by default
- instruct to run `generate_pdfs.py` before starting containers

## Testing
- `pip install -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792f0422b48326bd0beb12a396c2dd