### PR TITLE
Implement clickable event rows

### DIFF
--- a/frontend/src/pages/EventUpload.jsx
+++ b/frontend/src/pages/EventUpload.jsx
@@ -1,7 +1,13 @@
 import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import './EventUpload.css'
 
 function EventUpload() {
+  const [searchParams] = useSearchParams()
+  const eventId = searchParams.get('event_id')
+  const patientId = searchParams.get('patient_id')
+  const date = searchParams.get('date')
+  const criteria = searchParams.get('criteria')
   const [noPacketReason, setNoPacketReason] = useState('')
   const [priorEventDateKnown, setPriorEventDateKnown] = useState('')
 
@@ -20,6 +26,15 @@ function EventUpload() {
   return (
     <div>
       <h1>Upload Event Packet</h1>
+
+      {eventId && (
+        <div className="infobox">
+          <div>Packet for MI {eventId}</div>
+          <div>Patient ID: {patientId}</div>
+          <div>Date: {date}</div>
+          <div>Criteria: {criteria}</div>
+        </div>
+      )}
 
       <div className="infobox">
         <h3>Review packets should contain:</h3>

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -25,6 +25,10 @@
   padding: 4px 8px;
 }
 
+.data-table tr.clickable {
+  cursor: pointer;
+}
+
 .sections-grid {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import './Home.css'
 
 // Base URL for the backend API. When running under Docker Compose the
@@ -7,13 +8,16 @@ import './Home.css'
 const API_BASE = import.meta.env.VITE_API_URL || ''
 
 function Table({ rows }) {
+  const navigate = useNavigate()
   const [page, setPage] = useState(1)
   const pageSize = 20
 
   if (!rows.length) return <p>No data found.</p>
 
   const totalPages = Math.ceil(rows.length / pageSize)
-  const headers = Object.keys(rows[0])
+  const headers = ['ID', 'Patient ID', 'Date', 'Criteria'].filter(
+    (h) => h in rows[0]
+  )
   const pageRows = rows.slice((page - 1) * pageSize, page * pageSize)
 
   const goPrev = () => setPage(p => Math.max(1, p - 1))
@@ -31,7 +35,15 @@ function Table({ rows }) {
         </thead>
         <tbody>
           {pageRows.map((row, idx) => (
-            <tr key={idx}>
+            <tr
+              key={idx}
+              className="clickable"
+              onClick={() =>
+                navigate(
+                  `/events/upload?event_id=${row['ID']}&patient_id=${row['Patient ID']}&date=${row['Date']}&criteria=${encodeURIComponent(row['Criteria'])}`
+                )
+              }
+            >
               {headers.map(h => (
                 <td key={h}>{row[h]}</td>
               ))}


### PR DESCRIPTION
## Summary
- add navigation from home table rows to event upload
- show only ID/Patient ID/Date/Criteria
- include event info on upload page
- style row cursor

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792f6d362c8326b53a840ede2824a5