### PR TITLE
Implement reupload packets workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ backend/node_modules/*
 .env
 docker-compose.yaml
 app/webroot/files/*.pdf
+__pycache__/
+flask_backend/__pycache__/
+flask_backend/tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -76,4 +76,5 @@ See [docs/separation_of_duties.md](docs/separation_of_duties.md) for details on 
 - `/api/tables/<name>` – return rows from a database table.
 - `/api/events/need_packets` – events awaiting packet uploads.
 - `/api/events/for_review` – events with packets ready for review.
+- `/api/events/need_reupload` – events requiring packet re-upload.
 - `/api/events/status_summary` – counts of events grouped by status.

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -116,6 +116,17 @@ def events_for_review():
         return jsonify({'error': 'Failed to fetch table data'}), 500
 
 
+@app.route('/api/events/need_reupload')
+@requires_auth
+def events_need_reupload():
+    try:
+        rows = table_service.get_events_for_reupload()
+        return jsonify({'data': rows})
+    except Exception as exc:
+        print(exc)
+        return jsonify({'error': 'Failed to fetch table data'}), 500
+
+
 @app.route('/api/events/status_summary')
 @requires_auth
 def events_status_summary():

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -79,6 +79,27 @@ def get_events_for_review():
     return rows
 
 
+def get_events_for_reupload():
+    """Return up to 100 events that were rejected and need reupload."""
+    conn = get_pool().get_connection()
+    cursor = conn.cursor(dictionary=True)
+    query = (
+        "SELECT e.id AS `ID`, e.patient_id AS `Patient ID`, "
+        "e.event_date AS `Date`, "
+        "GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS `Criteria` "
+        "FROM events e "
+        "JOIN criterias c ON e.id = c.event_id "
+        "JOIN uw_patients2 p ON e.patient_id = p.id "
+        "WHERE e.status = 'rejected' "
+        "GROUP BY e.id LIMIT 100"
+    )
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return rows
+
+
 def get_event_status_summary():
     """Return a mapping of event status names to row counts."""
     conn = get_pool().get_connection()

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -64,6 +64,29 @@ def test_auth_required_for_review(mock_service):
     assert res.status_code == 401
 
 
+@patch('flask_backend.table_service.get_events_for_reupload')
+def test_get_for_reupload_route(mock_service):
+    mock_service.return_value = [{'ID': 3}]
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = None
+    client = app_mod.app.test_client()
+    res = client.get('/api/events/need_reupload')
+    assert res.status_code == 200
+    assert res.get_json() == {'data': [{'ID': 3}]}
+
+
+@patch('flask_backend.table_service.get_events_for_reupload')
+def test_auth_required_for_reupload(mock_service):
+    mock_service.return_value = []
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = object()
+    client = app_mod.app.test_client()
+    res = client.get('/api/events/need_reupload')
+    assert res.status_code == 401
+
+
 @patch('flask_backend.table_service.get_event_status_summary')
 def test_status_summary_route(mock_service):
     mock_service.return_value = {'uploaded': 5}

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -52,6 +52,23 @@ def test_get_events_for_review(mock_get_pool):
 
 
 @patch('flask_backend.table_service.get_pool')
+def test_get_events_for_reupload(mock_get_pool):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [{'ID': 3}]
+    mock_conn.cursor.return_value = mock_cursor
+    mock_get_pool.return_value.get_connection.return_value = mock_conn
+
+    rows = ts.get_events_for_reupload()
+
+    mock_get_pool.assert_called()
+    query = mock_cursor.execute.call_args.args[0]
+    assert "WHERE e.status = 'rejected'" in query
+    assert "GROUP BY e.id" in query
+    assert rows == [{'ID': 3}]
+
+
+@patch('flask_backend.table_service.get_pool')
 def test_get_event_status_summary(mock_get_pool):
     mock_conn = MagicMock()
     mock_cursor = MagicMock()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import EventAdd from './pages/EventAdd'
 import EventAddMany from './pages/EventAddMany'
 import EventAssignMany from './pages/EventAssignMany'
 import EventUpload from './pages/EventUpload'
+import EventReupload from './pages/EventReupload'
 import EventReview from './pages/EventReview'
 import EventScreen from './pages/EventScreen'
 import EventScrub from './pages/EventScrub'
@@ -35,6 +36,7 @@ function App() {
           <Route path="/events/addMany" element={<EventAddMany />} />
           <Route path="/events/assignMany" element={<EventAssignMany />} />
           <Route path="/events/upload" element={<EventUpload />} />
+          <Route path="/events/reupload" element={<EventReupload />} />
           <Route path="/events/review" element={<EventReview />} />
           <Route path="/events/screen" element={<EventScreen />} />
           <Route path="/events/scrub" element={<EventScrub />} />

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -64,7 +64,7 @@ function MenuBar({ admin, uploader, reviewer }) {
                   <Link to="/events/upload">Upload New Packets</Link>
                 </li>
                 <li>
-                  <Link to="/events/upload">Re-upload Existing Packets</Link>
+                  <Link to="/events/reupload">Re-upload Existing Packets</Link>
                 </li>
               </ul>
             </details>

--- a/frontend/src/pages/EventReupload.jsx
+++ b/frontend/src/pages/EventReupload.jsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import './Home.css'
+
+const API_BASE = import.meta.env.VITE_API_URL || ''
+
+function Table({ rows }) {
+  const navigate = useNavigate()
+  const [page, setPage] = useState(1)
+  const pageSize = 20
+
+  if (!rows.length) return <p>No data found.</p>
+
+  const totalPages = Math.ceil(rows.length / pageSize)
+  const headers = ['ID', 'Patient ID', 'Date', 'Criteria'].filter(
+    (h) => h in rows[0]
+  )
+  const pageRows = rows.slice((page - 1) * pageSize, page * pageSize)
+
+  const goPrev = () => setPage((p) => Math.max(1, p - 1))
+  const goNext = () => setPage((p) => Math.min(totalPages, p + 1))
+
+  return (
+    <>
+      <table className="data-table">
+        <thead>
+          <tr>
+            {headers.map((h) => (
+              <th key={h}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {pageRows.map((row, idx) => (
+            <tr
+              key={idx}
+              className="clickable"
+              onClick={() =>
+                navigate(
+                  `/events/upload?event_id=${row['ID']}&patient_id=${row['Patient ID']}&date=${row['Date']}&criteria=${encodeURIComponent(row['Criteria'])}`
+                )
+              }
+            >
+              {headers.map((h) => (
+                <td key={h}>{row[h]}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div className="pagination">
+          <button onClick={goPrev} disabled={page === 1}>
+            Previous
+          </button>
+          <span>
+            Page {page} of {totalPages}
+          </span>
+          <button onClick={goNext} disabled={page === totalPages}>
+            Next
+          </button>
+        </div>
+      )}
+    </>
+  )
+}
+
+function EventReupload() {
+  const [rows, setRows] = useState([])
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/events/need_reupload`)
+      .then((res) => res.json())
+      .then((json) => setRows(json.data || []))
+      .catch(() => {})
+  }, [])
+
+  return (
+    <div className="home-container">
+      <h1>Re-upload Existing Packets</h1>
+      {rows.length ? (
+        <p>{rows.length} event(s) require packet re-upload.</p>
+      ) : (
+        <p>No events currently require re-upload.</p>
+      )}
+
+      <section>
+        <Table rows={rows} />
+      </section>
+
+      <div className="infobox">
+        <h3>Review packets should contain:</h3>
+        <ol>
+          <li>Physician's notes closest to potential Event date</li>
+          <li>Outpatient cardiology consultations</li>
+          <li>In-patient cardiology notes or consults</li>
+          <li>Baseline ECG</li>
+          <li>First 2 ECGs after admission or in-hospital event</li>
+          <li>Related procedure and diagnostic test results</li>
+          <li>Related laboratory evidence</li>
+          <li>
+            Please redact the personal identifiers including name, birthday, and
+            hospital number
+          </li>
+        </ol>
+        <div>
+          Full instructions:{' '}
+          <a href={`${API_BASE}/files/CNICS MI Review packet assembly instructions.doc`} download>.doc</a>{' '}
+          |{' '}
+          <a
+            href={`${API_BASE}/files/CNICS MI Review packet assembly instructions.pdf`}
+            target="_blank"
+          >
+            .pdf
+          </a>
+        </div>
+      </div>
+
+      <div className="infobox">
+        <h3>Review Instructions:</h3>
+        <div>
+          View as:{' '}
+          <a href={`${API_BASE}/files/CNICS MI reviewer instructions.doc`} download>.doc</a>{' '}
+          |{' '}
+          <a href={`${API_BASE}/files/CNICS MI reviewer instructions.pdf`} target="_blank">
+            .pdf
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default EventReupload


### PR DESCRIPTION
## Summary
- add ignore rules for `__pycache__`
- support listing events that need reupload in backend
- expose `/api/events/need_reupload` endpoint
- display reupload events in new React page
- wire new page into menu and router
- document the new endpoint
- add unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a781c7d7483268bfdec81fd1837a6