### PR TITLE
Migrate backend to SQLAlchemy ORM

### DIFF
--- a/flask_backend/models.py
+++ b/flask_backend/models.py
@@ -1,0 +1,48 @@
+import os
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+load_dotenv()
+
+DB_CONFIG = {
+    'host': os.getenv('DB_HOST', 'localhost'),
+    'user': os.getenv('DB_USER', 'root'),
+    'password': os.getenv('DB_PASSWORD', ''),
+    'database': os.getenv('DB_NAME', 'mci'),
+}
+
+DATABASE_URL = (
+    f"mysql+mysqlconnector://{DB_CONFIG['user']}:{DB_CONFIG['password']}"
+    f"@{DB_CONFIG['host']}/{DB_CONFIG['database']}"
+)
+
+engine = create_engine(DATABASE_URL, pool_size=10)
+SessionLocal = sessionmaker(bind=engine)
+
+Base = declarative_base()
+
+class Event(Base):
+    __tablename__ = 'events'
+    id = Column(Integer, primary_key=True)
+    patient_id = Column(Integer, nullable=False)
+    event_date = Column(Date)
+    status = Column(String(50))
+    criterias = relationship('Criteria', back_populates='event')
+
+class Criteria(Base):
+    __tablename__ = 'criterias'
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey('events.id'))
+    name = Column(String(50))
+    value = Column(String(100))
+    event = relationship('Event', back_populates='criterias')
+
+class UwPatient2(Base):
+    __tablename__ = 'uw_patients2'
+    id = Column(Integer, primary_key=True)
+
+
+def get_session():
+    """Return a new SQLAlchemy session."""
+    return SessionLocal()

--- a/flask_backend/requirements.txt
+++ b/flask_backend/requirements.txt
@@ -8,3 +8,5 @@ python-docx
 reportlab
 apispec
 apispec-webframeworks
+
+SQLAlchemy

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -1,111 +1,61 @@
-import os
-import mysql.connector
-from mysql.connector.pooling import MySQLConnectionPool
-from dotenv import load_dotenv
+from sqlalchemy import Table, select, func
 
-load_dotenv()
-
-DB_CONFIG = {
-    'host': os.getenv('DB_HOST', 'localhost'),
-    'user': os.getenv('DB_USER', 'root'),
-    'password': os.getenv('DB_PASSWORD', ''),
-    'database': os.getenv('DB_NAME', 'mci'),
-}
-
-# Lazily initialized connection pool similar to the Node backend implementation
-POOL = None
+from . import models
 
 
-def get_pool():
-    global POOL
-    if POOL is None:
-        POOL = MySQLConnectionPool(
-            pool_name="mci_pool",
-            pool_size=10,
-            **DB_CONFIG,
-        )
-    return POOL
+def get_session():
+    """Lazily create a new SQLAlchemy session."""
+    return models.get_session()
 
 def get_table_data(name: str):
     """Return up to 100 rows from the specified table."""
-    conn = get_pool().get_connection()
-    cursor = conn.cursor(dictionary=True)
-    cursor.execute(f"SELECT * FROM `{name}` LIMIT 100")
-    rows = cursor.fetchall()
-    cursor.close()
-    conn.close()
+    session = get_session()
+    table = Table(name, models.Base.metadata, autoload_with=models.engine)
+    stmt = select(table).limit(100)
+    rows = session.execute(stmt).mappings().all()
+    session.close()
+    return rows
+
+
+def _events_by_status(status: str):
+    session = get_session()
+    stmt = (
+        select(
+            models.Event.id.label("ID"),
+            models.Event.patient_id.label("Patient ID"),
+            models.Event.event_date.label("Date"),
+            func.group_concat(models.Criteria.name).label("Criteria"),
+        )
+        .join(models.Criteria, models.Event.id == models.Criteria.event_id)
+        .join(models.UwPatient2, models.Event.patient_id == models.UwPatient2.id)
+        .where(models.Event.status == status)
+        .group_by(models.Event.id)
+        .limit(100)
+    )
+    rows = session.execute(stmt).mappings().all()
+    session.close()
     return rows
 
 
 def get_events_need_packets():
     """Return up to 100 events that still require packet uploads."""
-    conn = get_pool().get_connection()
-    cursor = conn.cursor(dictionary=True)
-    query = (
-        "SELECT e.id AS `ID`, e.patient_id AS `Patient ID`, "
-        "e.event_date AS `Date`, "
-        "GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS `Criteria` "
-        "FROM events e "
-        "JOIN criterias c ON e.id = c.event_id "
-        "JOIN uw_patients2 p ON e.patient_id = p.id "
-        "WHERE e.status = 'created' "
-        "GROUP BY e.id LIMIT 100"
-    )
-    cursor.execute(query)
-    rows = cursor.fetchall()
-    cursor.close()
-    conn.close()
-    return rows
+    return _events_by_status("created")
 
 
 def get_events_for_review():
     """Return up to 100 events with uploaded packets awaiting review."""
-    conn = get_pool().get_connection()
-    cursor = conn.cursor(dictionary=True)
-    query = (
-        "SELECT e.id AS `ID`, e.patient_id AS `Patient ID`, "
-        "e.event_date AS `Date`, "
-        "GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS `Criteria` "
-        "FROM events e "
-        "JOIN criterias c ON e.id = c.event_id "
-        "JOIN uw_patients2 p ON e.patient_id = p.id "
-        "WHERE e.status = 'uploaded' "
-        "GROUP BY e.id LIMIT 100"
-    )
-    cursor.execute(query)
-    rows = cursor.fetchall()
-    cursor.close()
-    conn.close()
-    return rows
+    return _events_by_status("uploaded")
 
 
 def get_events_for_reupload():
     """Return up to 100 events that were rejected and need reupload."""
-    conn = get_pool().get_connection()
-    cursor = conn.cursor(dictionary=True)
-    query = (
-        "SELECT e.id AS `ID`, e.patient_id AS `Patient ID`, "
-        "e.event_date AS `Date`, "
-        "GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS `Criteria` "
-        "FROM events e "
-        "JOIN criterias c ON e.id = c.event_id "
-        "JOIN uw_patients2 p ON e.patient_id = p.id "
-        "WHERE e.status = 'rejected' "
-        "GROUP BY e.id LIMIT 100"
-    )
-    cursor.execute(query)
-    rows = cursor.fetchall()
-    cursor.close()
-    conn.close()
-    return rows
+    return _events_by_status("rejected")
 
 
 def get_event_status_summary():
     """Return a mapping of event status names to row counts."""
-    conn = get_pool().get_connection()
-    cursor = conn.cursor(dictionary=True)
-    cursor.execute("SELECT status, COUNT(*) AS count FROM events GROUP BY status")
-    rows = cursor.fetchall()
-    cursor.close()
-    conn.close()
-    return {row["status"]: row["count"] for row in rows}
+    session = get_session()
+    stmt = select(models.Event.status, func.count().label("count")).group_by(models.Event.status)
+    rows = session.execute(stmt).all()
+    session.close()
+    return {row[0]: row[1] for row in rows}

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -2,82 +2,77 @@ from unittest.mock import MagicMock, patch
 import flask_backend.table_service as ts
 
 
-@patch('flask_backend.table_service.get_pool')
-def test_get_table_data(mock_get_pool):
-    mock_conn = MagicMock()
-    mock_cursor = MagicMock()
-    mock_cursor.fetchall.return_value = [{'id': 1}]
-    mock_conn.cursor.return_value = mock_cursor
-    mock_get_pool.return_value.get_connection.return_value = mock_conn
+@patch('flask_backend.table_service.models.get_session')
+def test_get_table_data(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'id': 1}
+    ]
+    mock_get_session.return_value = mock_session
 
     rows = ts.get_table_data('events')
 
-    mock_get_pool.assert_called()
-    mock_cursor.execute.assert_called_with('SELECT * FROM `events` LIMIT 100')
+    mock_get_session.assert_called()
+    mock_session.execute.assert_called()
     assert rows == [{'id': 1}]
 
 
-@patch('flask_backend.table_service.get_pool')
-def test_get_events_need_packets(mock_get_pool):
-    mock_conn = MagicMock()
-    mock_cursor = MagicMock()
-    mock_cursor.fetchall.return_value = [{'ID': 1}]
-    mock_conn.cursor.return_value = mock_cursor
-    mock_get_pool.return_value.get_connection.return_value = mock_conn
+@patch('flask_backend.table_service.models.get_session')
+def test_get_events_need_packets(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'ID': 1}
+    ]
+    mock_get_session.return_value = mock_session
 
     rows = ts.get_events_need_packets()
 
-    mock_get_pool.assert_called()
-    query = mock_cursor.execute.call_args.args[0]
-    assert "GROUP BY e.id" in query
-    assert "JOIN uw_patients2" in query
+    mock_get_session.assert_called()
+    query = mock_session.execute.call_args.args[0]
+    assert 'events.status' in str(query)
     assert rows == [{'ID': 1}]
 
 
-@patch('flask_backend.table_service.get_pool')
-def test_get_events_for_review(mock_get_pool):
-    mock_conn = MagicMock()
-    mock_cursor = MagicMock()
-    mock_cursor.fetchall.return_value = [{'ID': 2}]
-    mock_conn.cursor.return_value = mock_cursor
-    mock_get_pool.return_value.get_connection.return_value = mock_conn
+@patch('flask_backend.table_service.models.get_session')
+def test_get_events_for_review(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'ID': 2}
+    ]
+    mock_get_session.return_value = mock_session
 
     rows = ts.get_events_for_review()
 
-    mock_get_pool.assert_called()
-    query = mock_cursor.execute.call_args.args[0]
-    assert "WHERE e.status = 'uploaded'" in query
-    assert "GROUP BY e.id" in query
+    mock_get_session.assert_called()
+    query = mock_session.execute.call_args.args[0]
+    assert 'events.status' in str(query)
     assert rows == [{'ID': 2}]
 
 
-@patch('flask_backend.table_service.get_pool')
-def test_get_events_for_reupload(mock_get_pool):
-    mock_conn = MagicMock()
-    mock_cursor = MagicMock()
-    mock_cursor.fetchall.return_value = [{'ID': 3}]
-    mock_conn.cursor.return_value = mock_cursor
-    mock_get_pool.return_value.get_connection.return_value = mock_conn
+@patch('flask_backend.table_service.models.get_session')
+def test_get_events_for_reupload(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'ID': 3}
+    ]
+    mock_get_session.return_value = mock_session
 
     rows = ts.get_events_for_reupload()
 
-    mock_get_pool.assert_called()
-    query = mock_cursor.execute.call_args.args[0]
-    assert "WHERE e.status = 'rejected'" in query
-    assert "GROUP BY e.id" in query
+    mock_get_session.assert_called()
+    query = mock_session.execute.call_args.args[0]
+    assert 'events.status' in str(query)
     assert rows == [{'ID': 3}]
 
 
-@patch('flask_backend.table_service.get_pool')
-def test_get_event_status_summary(mock_get_pool):
-    mock_conn = MagicMock()
-    mock_cursor = MagicMock()
-    mock_cursor.fetchall.return_value = [{'status': 'created', 'count': 3}]
-    mock_conn.cursor.return_value = mock_cursor
-    mock_get_pool.return_value.get_connection.return_value = mock_conn
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_status_summary(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.all.return_value = [('created', 3)]
+    mock_get_session.return_value = mock_session
 
     summary = ts.get_event_status_summary()
 
-    mock_get_pool.assert_called()
-    mock_cursor.execute.assert_called()
+    mock_get_session.assert_called()
+    mock_session.execute.assert_called()
     assert summary == {'created': 3}


### PR DESCRIPTION
## Summary
- add SQLAlchemy dependency
- create SQLAlchemy models and connection handling
- rewrite `table_service` to use ORM
- update tests for ORM functions

## Testing
- `pip install -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6679e8ac8326bf4e4bff63d45bc1