### PR TITLE
Update unit tests for ORM changes

### DIFF
--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -27,10 +27,10 @@ def test_get_events_need_packets(mock_get_session):
 
     rows = ts.get_events_need_packets()
 
-    mock_get_pool.assert_called()
-    query = mock_cursor.execute.call_args.args[0]
-    assert "GROUP BY e.id" in query
-    assert "JOIN patients_view" in query
+    mock_get_session.assert_called()
+    query = mock_session.execute.call_args.args[0]
+    assert "GROUP BY events.id" in str(query)
+    assert "JOIN patients_view" in str(query)
     assert rows == [{'ID': 1}]
 
 


### PR DESCRIPTION
## Summary
- fix failing tests after refactoring event query logic to SQLAlchemy
- assert session usage and executed SQL text

## Testing
- `pytest -q`
- `python - <<'EOF'
from flask_backend import table_service as ts
class Session:
    def execute(self, stmt, *args, **kwargs):
        print('executing', stmt)
        class Res:
            def mappings(self):
                class All:
                    def all(self):
                        return [{'id': 1}]
                return All()
        return Res()
    def close(self):
        print('session closed')

def get_session():
    print('new session')
    return Session()

ts.models.get_session = get_session
print(ts.get_table_data('events'))
EOF`
- `python - <<'EOF'
from flask_backend import table_service as ts
class Session:
    def execute(self, stmt, params=None):
        print('executing', stmt, params)
        class Res:
            def mappings(self):
                class All:
                    def all(self):
                        return [{'ID': 2}]
                return All()
            def all(self):
                return [('uploaded', 1)]
        return Res()
    def close(self):
        print('session closed')

def get_session():
    print('new session')
    return Session()

ts.models.get_session = get_session
print(ts.get_events_for_review())
print(ts.get_event_status_summary())
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687dd0775ae0832684b154ee79fc1f4a