### PR TITLE
Fix workflow dependencies for openapi generation

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install apispec apispec-webframeworks flask flask-cors mysql-connector-python python-dotenv python-keycloak python-docx reportlab
+      - run: pip install -r flask_backend/requirements.txt
       - run: python scripts/generate_openapi.py
       - run: |
           if ! git diff --quiet openapi.json; then


### PR DESCRIPTION
## Summary
- install backend requirements in `update-openapi.yml`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e660fb3888326b0aee6ac5f93dde2