### PR TITLE
Fix backend database session

### DIFF
--- a/flask_backend/models.py
+++ b/flask_backend/models.py
@@ -1,8 +1,9 @@
 from typing import Optional
-from sqlalchemy import Column, Date, DateTime, Enum, Float, String, TIMESTAMP, text, ForeignKey
+from sqlalchemy import Column, Date, DateTime, Enum, Float, String, TIMESTAMP, text, ForeignKey, create_engine
 from sqlalchemy.dialects.mysql import INTEGER, TINYINT, VARCHAR
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
 import datetime
+import os
 
 class Base(DeclarativeBase):
     pass
@@ -162,4 +163,23 @@ t_uw_patients2 = Table(
     Column('last_update', TIMESTAMP, nullable=False, server_default=text("'0000-00-00 00:00:00'")),
     Column('create_date', DateTime, nullable=False, server_default=text("'0000-00-00 00:00:00'"))
 )
+
+# --- Database session handling -------------------------------------------------
+_engine = None
+_Session = None
+
+
+def get_session():
+    """Return a new SQLAlchemy session configured from environment variables."""
+    global _engine, _Session
+    if _engine is None:
+        user = os.getenv("DB_USER", "root")
+        pw = os.getenv("DB_PASSWORD", "")
+        host = os.getenv("DB_HOST", "localhost")
+        db = os.getenv("DB_NAME", "cnics")
+        url = f"mysql+mysqlconnector://{user}:{pw}@{host}/{db}"
+        _engine = create_engine(url, pool_pre_ping=True)
+        _Session = sessionmaker(bind=_engine)
+    return _Session()
+
 


### PR DESCRIPTION
## Summary
- create SQLAlchemy engine on demand in `models.py`
- add environment-configured `get_session`

## Testing
- `pip install -r flask_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6b7623f083269ee101c922f05e25