### PR TITLE
Fix DB name mismatch

### DIFF
--- a/init/01-create-db.sql
+++ b/init/01-create-db.sql
@@ -1,2 +1,2 @@
-CREATE DATABASE IF NOT EXISTS `mci`;
-USE `mci`;
+CREATE DATABASE IF NOT EXISTS `cnics_mci`;
+USE `cnics_mci`;


### PR DESCRIPTION
## Summary
- update init DB script to use the same name as `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e6ea745cc832694f37420234edf74