### PR TITLE
Add external DB configuration and helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,6 @@ VITE_API_URL=http://localhost:3001
 FHIR_SERVER=http://example-fhir-server.com
 # Directory containing instruction files to serve via the backend
 FILES_DIR=./app/webroot/files
+# SQLAlchemy URL for a secondary database (optional)
+EXTERNAL_DB_URL=
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ services are built or started. The template defines the following variables:
 - `FRONTEND_ORIGIN` – allowed origin for CORS requests to the backend.
 - `FHIR_SERVER` – URL of the FHIR server used by the application.
 - `FILES_DIR` – directory containing instruction files served by the backend.
+- `EXTERNAL_DB_URL` – optional SQLAlchemy URL for a secondary database.
 
 Override these values in your copied `.env` file as needed.
 

--- a/default.env
+++ b/default.env
@@ -5,3 +5,5 @@ FHIR_SERVER=http://example-fhir-server.com
 VITE_API_URL=http://localhost:3001
 # Allowed origin for CORS requests to the backend
 FRONTEND_ORIGIN=http://localhost:3000
+# Example URL for an additional database
+EXTERNAL_DB_URL=

--- a/flask_backend/models.py
+++ b/flask_backend/models.py
@@ -174,6 +174,8 @@ t_uw_patients2 = Table(
 # --- Database session handling -------------------------------------------------
 _engine = None
 _SessionFactory = None
+_external_engine = None
+_ExternalSessionFactory = None
 
 
 def get_engine():
@@ -195,5 +197,24 @@ def get_session() -> Session:
     if _SessionFactory is None:
         _SessionFactory = sessionmaker(bind=get_engine())
     return _SessionFactory()
+
+
+def get_external_engine():
+    """Create and return an engine for the external database."""
+    global _external_engine
+    if _external_engine is None:
+        url = os.getenv("EXTERNAL_DB_URL")
+        if not url:
+            raise RuntimeError("EXTERNAL_DB_URL is not configured")
+        _external_engine = create_engine(url, pool_pre_ping=True)
+    return _external_engine
+
+
+def get_external_session() -> Session:
+    """Return a new SQLAlchemy session for the external database."""
+    global _ExternalSessionFactory
+    if _ExternalSessionFactory is None:
+        _ExternalSessionFactory = sessionmaker(bind=get_external_engine())
+    return _ExternalSessionFactory()
 
 

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
-from sqlalchemy import text
+from sqlalchemy import text, bindparam
 
 try:
     from . import models  # type: ignore
 except Exception:  # pragma: no cover - models may not be importable during tests
-    models = SimpleNamespace(get_session=lambda: None)
+    models = SimpleNamespace(get_session=lambda: None, get_external_session=lambda: None)
 
 
 def get_session():
@@ -61,3 +61,26 @@ def get_event_status_summary():
     rows = session.execute(stmt).all()
     session.close()
     return {row[0]: row[1] for row in rows}
+
+
+def get_events_with_patient_site():
+    """Return events with site info from the external database."""
+    session = get_session()
+    rows = session.execute(text("SELECT id, patient_id FROM events LIMIT 100")).mappings().all()
+    session.close()
+
+    patient_ids = [row["patient_id"] for row in rows]
+    ext_session = models.get_external_session()
+    if patient_ids:
+        stmt = text("SELECT id, site FROM uw_patients2 WHERE id IN :ids").bindparams(
+            bindparam("ids", expanding=True)
+        )
+        ext_rows = ext_session.execute(stmt, {"ids": patient_ids}).mappings().all()
+    else:
+        ext_rows = []
+    ext_session.close()
+
+    lookup = {r["id"]: r["site"] for r in ext_rows}
+    for r in rows:
+        r["site"] = lookup.get(r["patient_id"])
+    return rows

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -77,3 +77,25 @@ def test_get_event_status_summary(mock_get_session):
     mock_get_session.assert_called()
     mock_session.execute.assert_called()
     assert summary == {'created': 3}
+
+
+@patch('flask_backend.table_service.models.get_external_session')
+@patch('flask_backend.table_service.models.get_session')
+def test_get_events_with_patient_site(mock_get_session, mock_get_external_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'id': 1, 'patient_id': 10}
+    ]
+    mock_get_session.return_value = mock_session
+
+    mock_ext_session = MagicMock()
+    mock_ext_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'id': 10, 'site': 'UW'}
+    ]
+    mock_get_external_session.return_value = mock_ext_session
+
+    rows = ts.get_events_with_patient_site()
+
+    mock_get_session.assert_called()
+    mock_get_external_session.assert_called()
+    assert rows == [{'id': 1, 'patient_id': 10, 'site': 'UW'}]


### PR DESCRIPTION
## Summary
- document new `EXTERNAL_DB_URL` variable
- add `get_external_engine()` and `get_external_session()` helpers
- support external DB queries in `table_service`
- demonstrate integration with new `get_events_with_patient_site()`
- test external DB logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd1e2ab1c8326a83c8e0d8574fbbc