### PR TITLE
Fix missing patients_view error and RowMapping JSON issue

### DIFF
--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -18,7 +18,7 @@ def get_table_data(name: str):
     stmt = text(f"SELECT * FROM {name} LIMIT 100")
     rows = session.execute(stmt).mappings().all()
     session.close()
-    return rows
+    return [dict(r) for r in rows]
 
 
 def get_events_by_status(status: str):
@@ -30,13 +30,13 @@ def get_events_by_status(status: str):
         "GROUP_CONCAT(criterias.name ORDER BY criterias.name SEPARATOR ', ') AS `Criteria` "
         "FROM events "
         "JOIN criterias ON events.id = criterias.event_id "
-        "JOIN patients_view ON events.patient_id = patients_view.id "
+        "JOIN patients ON events.patient_id = patients.id "
         "WHERE events.status = :status "
         "GROUP BY events.id, events.patient_id, events.event_date LIMIT 100"
     )
     rows = session.execute(text(query), {"status": status}).mappings().all()
     session.close()
-    return rows
+    return [dict(r) for r in rows]
 
 
 def get_events_need_packets():
@@ -68,6 +68,7 @@ def get_events_with_patient_site():
     session = get_session()
     rows = session.execute(text("SELECT id, patient_id FROM events LIMIT 100")).mappings().all()
     session.close()
+    rows = [dict(r) for r in rows]
 
     patient_ids = [row["patient_id"] for row in rows]
     ext_session = models.get_external_session()
@@ -76,6 +77,7 @@ def get_events_with_patient_site():
             bindparam("ids", expanding=True)
         )
         ext_rows = ext_session.execute(stmt, {"ids": patient_ids}).mappings().all()
+        ext_rows = [dict(r) for r in ext_rows]
     else:
         ext_rows = []
     ext_session.close()

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -30,7 +30,7 @@ def test_get_events_need_packets(mock_get_session):
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert "GROUP BY events.id" in str(query)
-    assert "JOIN patients_view" in str(query)
+    assert "JOIN patients" in str(query)
     assert rows == [{'ID': 1}]
 
 


### PR DESCRIPTION
## Summary
- fix SQL join to reference `patients` instead of the removed `patients_view`
- convert SQLAlchemy `RowMapping` results to plain dictionaries
- update tests for new join

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826eddd8e48326afc74d1285ad9fb7