### PR TITLE
Add automatic patients table init

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ DOCKER DATABASE:
 
         cp .env.example .env
         docker-compose up -d mariadb
-        # Initialization scripts load `cnics.sql`
+        # Initialization scripts load `init/04-create-patients.sql` which
+        # populates the `patients` table from `uw_patients2` if it does not
+        # already exist
 
 ## Container Setup
 

--- a/flask_backend/README.md
+++ b/flask_backend/README.md
@@ -22,5 +22,6 @@ If the environment variable `KEYCLOAK_REALM` is set, requests are validated
 against a Keycloak server. Configure `KEYCLOAK_URL`, `KEYCLOAK_CLIENT_ID` and
 `KEYCLOAK_CLIENT_SECRET` accordingly.
 
-A sample CNICS database dump `cnics.sql` is provided in this directory for local
-testing. Load it into your MariaDB instance after creating the schema.
+The repo includes a sample CNICS dump `cnics.sql` for reference. When the
+database container initializes it runs `init/04-create-patients.sql`, which
+creates and populates the `patients` table from `uw_patients2` if it is missing.

--- a/init/04-create-patients.sql
+++ b/init/04-create-patients.sql
@@ -1,0 +1,14 @@
+-- Ensure `patients` table exists and populate from `uw_patients2` if missing
+CREATE TABLE IF NOT EXISTS `patients` (
+  `id` int(10) unsigned NOT NULL,
+  `site_patient_id` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `site` varchar(20) NOT NULL,
+  `last_update` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `create_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+INSERT INTO `patients`
+SELECT * FROM `uw_patients2`
+WHERE NOT EXISTS (SELECT 1 FROM `patients` LIMIT 1) AND id <> 0;
+


### PR DESCRIPTION
## Summary
- add init script to ensure `patients` table exists and is populated
- document the new script in READMEs

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886ca15b3008326b835be26c89a62b1