### PR TITLE
Fix homepage pagination

### DIFF
--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,9 +1,14 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import "./DataTable.css"
 
 function DataTable({ rows, onRowClick }) {
   const [page, setPage] = useState(1)
   const pageSize = 20
+
+  // Reset back to the first page whenever the row set changes
+  useEffect(() => {
+    setPage(1)
+  }, [rows])
 
   if (!rows.length) return <p>No data found.</p>
 
@@ -40,7 +45,7 @@ function DataTable({ rows, onRowClick }) {
           ))}
         </tbody>
       </table>
-      {totalPages > 1 && (
+      {rows.length > pageSize && (
         <div className="pagination">
           <button onClick={goPrev} disabled={page === 1}>
             Previous

--- a/frontend/src/pages/EventReupload.jsx
+++ b/frontend/src/pages/EventReupload.jsx
@@ -9,6 +9,11 @@ function Table({ rows }) {
   const [page, setPage] = useState(1)
   const pageSize = 20
 
+  // Reset page when new rows come in so pagination stays in range
+  useEffect(() => {
+    setPage(1)
+  }, [rows])
+
   if (!rows.length) return <p>No data found.</p>
 
   const totalPages = Math.ceil(rows.length / pageSize)
@@ -48,7 +53,7 @@ function Table({ rows }) {
           ))}
         </tbody>
       </table>
-      {totalPages > 1 && (
+      {rows.length > pageSize && (
         <div className="pagination">
           <button onClick={goPrev} disabled={page === 1}>
             Previous


### PR DESCRIPTION
## Summary
- reset page to 1 when results change in `DataTable`
- only display pagination if more than 20 items in table
- keep `EventReupload` table pagination consistent with `DataTable`

## Testing
- `pip install -q -r flask_backend/requirements.txt`
- `pytest -q`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68879c4d0cfc8326af009bc572a53a35