### PR TITLE
Add parameterized limit for event pagination

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -32,6 +32,14 @@ if not FILES_DIR:
 os.makedirs(FILES_DIR, exist_ok=True)
 
 
+def get_limit(default: int = 100) -> int:
+    """Return the integer limit requested by the client."""
+    try:
+        return int(request.args.get("limit", default))
+    except (TypeError, ValueError):
+        return default
+
+
 def ensure_pdf(doc_path: str, pdf_path: str) -> None:
     """Create a PDF from a doc/docx file if the PDF does not exist."""
     if os.path.exists(pdf_path):
@@ -109,8 +117,9 @@ def get_table(name):
               items:
                 type: object
     """
+    limit = get_limit()
     try:
-        rows = table_service.get_table_data(name)
+        rows = table_service.get_table_data(name, limit)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")
@@ -133,8 +142,9 @@ def events_need_packets():
               items:
                 type: object
     """
+    limit = get_limit()
     try:
-        rows = table_service.get_events_need_packets()
+        rows = table_service.get_events_need_packets(limit)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")
@@ -157,8 +167,9 @@ def events_for_review():
               items:
                 type: object
     """
+    limit = get_limit()
     try:
-        rows = table_service.get_events_for_review()
+        rows = table_service.get_events_for_review(limit)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")
@@ -168,8 +179,9 @@ def events_for_review():
 @app.route('/api/events/need_reupload')
 @requires_auth
 def events_need_reupload():
+    limit = get_limit()
     try:
-        rows = table_service.get_events_for_reupload()
+        rows = table_service.get_events_for_reupload(limit)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -15,20 +15,20 @@ def get_session():
     return models.get_session()
 
 
-def get_table_data(name: str):
-    """Return up to 100 rows from the specified table."""
-    logger.debug("Fetching up to 100 rows from table %s", name)
+def get_table_data(name: str, limit: int = 100):
+    """Return up to ``limit`` rows from the specified table."""
+    logger.debug("Fetching up to %d rows from table %s", limit, name)
     session = get_session()
-    stmt = text(f"SELECT * FROM {name} LIMIT 100")
-    rows = session.execute(stmt).mappings().all()
+    stmt = text(f"SELECT * FROM {name} LIMIT :limit")
+    rows = session.execute(stmt, {"limit": limit}).mappings().all()
     logger.debug("Fetched %d rows from table %s", len(rows), name)
     session.close()
     return [dict(r) for r in rows]
 
 
-def get_events_by_status(status: str):
-    """Return up to 100 events filtered by status."""
-    logger.debug("Fetching events with status %s", status)
+def get_events_by_status(status: str, limit: int = 100):
+    """Return up to ``limit`` events filtered by status."""
+    logger.debug("Fetching up to %d events with status %s", limit, status)
     session = get_session()
     query = (
         "SELECT events.id AS `ID`, events.patient_id AS `Patient ID`, "
@@ -38,27 +38,27 @@ def get_events_by_status(status: str):
         "JOIN criterias ON events.id = criterias.event_id "
         "JOIN patients ON events.patient_id = patients.id "
         "WHERE events.status = :status "
-        "GROUP BY events.id, events.patient_id, events.event_date LIMIT 100"
+        "GROUP BY events.id, events.patient_id, events.event_date LIMIT :limit"
     )
-    rows = session.execute(text(query), {"status": status}).mappings().all()
+    rows = session.execute(text(query), {"status": status, "limit": limit}).mappings().all()
     logger.debug("Fetched %d events with status %s", len(rows), status)
     session.close()
     return [dict(r) for r in rows]
 
 
-def get_events_need_packets():
-    """Return up to 100 events that still require packet uploads."""
-    return get_events_by_status("created")
+def get_events_need_packets(limit: int = 100):
+    """Return up to ``limit`` events that still require packet uploads."""
+    return get_events_by_status("created", limit)
 
 
-def get_events_for_review():
-    """Return up to 100 events with uploaded packets awaiting review."""
-    return get_events_by_status("uploaded")
+def get_events_for_review(limit: int = 100):
+    """Return up to ``limit`` events with uploaded packets awaiting review."""
+    return get_events_by_status("uploaded", limit)
 
 
-def get_events_for_reupload():
-    """Return up to 100 events that were rejected and need reupload."""
-    return get_events_by_status("rejected")
+def get_events_for_reupload(limit: int = 100):
+    """Return up to ``limit`` events that were rejected and need reupload."""
+    return get_events_by_status("rejected", limit)
 
 
 def get_event_status_summary():

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -5,18 +5,20 @@ from unittest.mock import patch
 def test_get_table_route(mock_service):
     mock_service.return_value = [{'id': 1}]
     client = app.test_client()
-    res = client.get('/api/tables/events')
+    res = client.get('/api/tables/events?limit=5')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'id': 1}]}
+    mock_service.assert_called_with('events', 5)
 
 
 @patch('flask_backend.table_service.get_events_need_packets')
 def test_get_need_packets_route(mock_service):
     mock_service.return_value = [{'ID': 1}]
     client = app.test_client()
-    res = client.get('/api/events/need_packets')
+    res = client.get('/api/events/need_packets?limit=2')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'ID': 1}]}
+    mock_service.assert_called_with(2)
 
 
 @patch("flask_backend.table_service.get_table_data")
@@ -48,9 +50,10 @@ def test_get_for_review_route(mock_service):
     app_mod = importlib.import_module('flask_backend.app')
     app_mod.keycloak_openid = None
     client = app_mod.app.test_client()
-    res = client.get('/api/events/for_review')
+    res = client.get('/api/events/for_review?limit=3')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'ID': 2}]}
+    mock_service.assert_called_with(3)
 
 
 @patch('flask_backend.table_service.get_events_for_review')
@@ -71,9 +74,10 @@ def test_get_for_reupload_route(mock_service):
     app_mod = importlib.import_module('flask_backend.app')
     app_mod.keycloak_openid = None
     client = app_mod.app.test_client()
-    res = client.get('/api/events/need_reupload')
+    res = client.get('/api/events/need_reupload?limit=4')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'ID': 3}]}
+    mock_service.assert_called_with(4)
 
 
 @patch('flask_backend.table_service.get_events_for_reupload')

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -10,10 +10,11 @@ def test_get_table_data(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_table_data('events')
+    rows = ts.get_table_data('events', 10)
 
     mock_get_session.assert_called()
     mock_session.execute.assert_called()
+    assert mock_session.execute.call_args.args[1] == {'limit': 10}
     assert rows == [{'id': 1}]
 
 
@@ -25,12 +26,13 @@ def test_get_events_need_packets(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_events_need_packets()
+    rows = ts.get_events_need_packets(5)
 
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert "GROUP BY events.id" in str(query)
     assert "JOIN patients" in str(query)
+    assert mock_session.execute.call_args.args[1] == {'status': 'created', 'limit': 5}
     assert rows == [{'ID': 1}]
 
 
@@ -42,11 +44,12 @@ def test_get_events_for_review(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_events_for_review()
+    rows = ts.get_events_for_review(6)
 
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert 'events.status' in str(query)
+    assert mock_session.execute.call_args.args[1] == {'status': 'uploaded', 'limit': 6}
     assert rows == [{'ID': 2}]
 
 
@@ -58,11 +61,12 @@ def test_get_events_for_reupload(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_events_for_reupload()
+    rows = ts.get_events_for_reupload(7)
 
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert 'events.status' in str(query)
+    assert mock_session.execute.call_args.args[1] == {'status': 'rejected', 'limit': 7}
     assert rows == [{'ID': 3}]
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -7,6 +7,11 @@ paths:
         type: string
         required: true
         description: Name of the table
+      - name: limit
+        in: query
+        type: integer
+        required: false
+        description: Maximum number of records to return
       responses:
         '200':
           description: Table rows
@@ -19,6 +24,12 @@ paths:
                   type: object
   /api/events/need_packets:
     get:
+      parameters:
+      - name: limit
+        in: query
+        type: integer
+        required: false
+        description: Maximum number of records to return
       responses:
         '200':
           description: Event rows
@@ -31,6 +42,12 @@ paths:
                   type: object
   /api/events/for_review:
     get:
+      parameters:
+      - name: limit
+        in: query
+        type: integer
+        required: false
+        description: Maximum number of records to return
       responses:
         '200':
           description: Event rows


### PR DESCRIPTION
## Summary
- allow API routes to specify record limit
- wire up query param for `/api/events/need_packets` and `/api/events/for_review`
- update table service helpers to accept limit argument
- document new optional `limit` query parameter in `openapi.json`
- adjust tests for new arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a33992c408326b25dd55a987d0a71