### PR TITLE
Show pagination when single page

### DIFF
--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -45,7 +45,7 @@ function DataTable({ rows, onRowClick }) {
           ))}
         </tbody>
       </table>
-      {rows.length > pageSize && (
+      {rows.length > 0 && (
         <div className="pagination">
           <button onClick={goPrev} disabled={page === 1}>
             Previous

--- a/frontend/src/pages/EventReupload.jsx
+++ b/frontend/src/pages/EventReupload.jsx
@@ -53,7 +53,7 @@ function Table({ rows }) {
           ))}
         </tbody>
       </table>
-      {rows.length > pageSize && (
+      {rows.length > 0 && (
         <div className="pagination">
           <button onClick={goPrev} disabled={page === 1}>
             Previous


### PR DESCRIPTION
## Summary
- always show pagination UI for DataTable
- do the same for EventReupload's table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a3cba12208326995d87b6c19a1927