### PR TITLE
Implement server-side pagination

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -40,6 +40,14 @@ def get_limit(default: int = 100) -> int:
         return default
 
 
+def get_offset(default: int = 0) -> int:
+    """Return the integer offset requested by the client."""
+    try:
+        return int(request.args.get("offset", default))
+    except (TypeError, ValueError):
+        return default
+
+
 def ensure_pdf(doc_path: str, pdf_path: str) -> None:
     """Create a PDF from a doc/docx file if the PDF does not exist."""
     if os.path.exists(pdf_path):
@@ -118,8 +126,9 @@ def get_table(name):
                 type: object
     """
     limit = get_limit()
+    offset = get_offset()
     try:
-        rows = table_service.get_table_data(name, limit)
+        rows = table_service.get_table_data(name, limit, offset)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")
@@ -143,8 +152,9 @@ def events_need_packets():
                 type: object
     """
     limit = get_limit()
+    offset = get_offset()
     try:
-        rows = table_service.get_events_need_packets(limit)
+        rows = table_service.get_events_need_packets(limit, offset)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")
@@ -168,8 +178,9 @@ def events_for_review():
                 type: object
     """
     limit = get_limit()
+    offset = get_offset()
     try:
-        rows = table_service.get_events_for_review(limit)
+        rows = table_service.get_events_for_review(limit, offset)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")
@@ -180,8 +191,9 @@ def events_for_review():
 @requires_auth
 def events_need_reupload():
     limit = get_limit()
+    offset = get_offset()
     try:
-        rows = table_service.get_events_for_reupload(limit)
+        rows = table_service.get_events_for_reupload(limit, offset)
         return jsonify({'data': rows})
     except Exception:
         app.logger.exception("Failed to fetch table data")

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -15,20 +15,20 @@ def get_session():
     return models.get_session()
 
 
-def get_table_data(name: str, limit: int = 100):
-    """Return up to ``limit`` rows from the specified table."""
-    logger.debug("Fetching up to %d rows from table %s", limit, name)
+def get_table_data(name: str, limit: int = 100, offset: int = 0):
+    """Return rows from ``name`` with ``limit`` and ``offset``."""
+    logger.debug("Fetching up to %d rows from table %s starting at %d", limit, name, offset)
     session = get_session()
-    stmt = text(f"SELECT * FROM {name} LIMIT :limit")
-    rows = session.execute(stmt, {"limit": limit}).mappings().all()
+    stmt = text(f"SELECT * FROM {name} LIMIT :limit OFFSET :offset")
+    rows = session.execute(stmt, {"limit": limit, "offset": offset}).mappings().all()
     logger.debug("Fetched %d rows from table %s", len(rows), name)
     session.close()
     return [dict(r) for r in rows]
 
 
-def get_events_by_status(status: str, limit: int = 100):
-    """Return up to ``limit`` events filtered by status."""
-    logger.debug("Fetching up to %d events with status %s", limit, status)
+def get_events_by_status(status: str, limit: int = 100, offset: int = 0):
+    """Return events filtered by status with pagination."""
+    logger.debug("Fetching up to %d events with status %s starting at %d", limit, status, offset)
     session = get_session()
     query = (
         "SELECT events.id AS `ID`, events.patient_id AS `Patient ID`, "
@@ -38,27 +38,27 @@ def get_events_by_status(status: str, limit: int = 100):
         "JOIN criterias ON events.id = criterias.event_id "
         "JOIN patients ON events.patient_id = patients.id "
         "WHERE events.status = :status "
-        "GROUP BY events.id, events.patient_id, events.event_date LIMIT :limit"
+        "GROUP BY events.id, events.patient_id, events.event_date LIMIT :limit OFFSET :offset"
     )
-    rows = session.execute(text(query), {"status": status, "limit": limit}).mappings().all()
+    rows = session.execute(text(query), {"status": status, "limit": limit, "offset": offset}).mappings().all()
     logger.debug("Fetched %d events with status %s", len(rows), status)
     session.close()
     return [dict(r) for r in rows]
 
 
-def get_events_need_packets(limit: int = 100):
-    """Return up to ``limit`` events that still require packet uploads."""
-    return get_events_by_status("created", limit)
+def get_events_need_packets(limit: int = 100, offset: int = 0):
+    """Return events that still require packet uploads."""
+    return get_events_by_status("created", limit, offset)
 
 
-def get_events_for_review(limit: int = 100):
-    """Return up to ``limit`` events with uploaded packets awaiting review."""
-    return get_events_by_status("uploaded", limit)
+def get_events_for_review(limit: int = 100, offset: int = 0):
+    """Return events with uploaded packets awaiting review."""
+    return get_events_by_status("uploaded", limit, offset)
 
 
-def get_events_for_reupload(limit: int = 100):
-    """Return up to ``limit`` events that were rejected and need reupload."""
-    return get_events_by_status("rejected", limit)
+def get_events_for_reupload(limit: int = 100, offset: int = 0):
+    """Return events that were rejected and need reupload."""
+    return get_events_by_status("rejected", limit, offset)
 
 
 def get_event_status_summary():

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -5,20 +5,20 @@ from unittest.mock import patch
 def test_get_table_route(mock_service):
     mock_service.return_value = [{'id': 1}]
     client = app.test_client()
-    res = client.get('/api/tables/events?limit=5')
+    res = client.get('/api/tables/events?limit=5&offset=10')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'id': 1}]}
-    mock_service.assert_called_with('events', 5)
+    mock_service.assert_called_with('events', 5, 10)
 
 
 @patch('flask_backend.table_service.get_events_need_packets')
 def test_get_need_packets_route(mock_service):
     mock_service.return_value = [{'ID': 1}]
     client = app.test_client()
-    res = client.get('/api/events/need_packets?limit=2')
+    res = client.get('/api/events/need_packets?limit=2&offset=5')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'ID': 1}]}
-    mock_service.assert_called_with(2)
+    mock_service.assert_called_with(2, 5)
 
 
 @patch("flask_backend.table_service.get_table_data")
@@ -50,10 +50,10 @@ def test_get_for_review_route(mock_service):
     app_mod = importlib.import_module('flask_backend.app')
     app_mod.keycloak_openid = None
     client = app_mod.app.test_client()
-    res = client.get('/api/events/for_review?limit=3')
+    res = client.get('/api/events/for_review?limit=3&offset=0')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'ID': 2}]}
-    mock_service.assert_called_with(3)
+    mock_service.assert_called_with(3, 0)
 
 
 @patch('flask_backend.table_service.get_events_for_review')
@@ -74,10 +74,10 @@ def test_get_for_reupload_route(mock_service):
     app_mod = importlib.import_module('flask_backend.app')
     app_mod.keycloak_openid = None
     client = app_mod.app.test_client()
-    res = client.get('/api/events/need_reupload?limit=4')
+    res = client.get('/api/events/need_reupload?limit=4&offset=0')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'ID': 3}]}
-    mock_service.assert_called_with(4)
+    mock_service.assert_called_with(4, 0)
 
 
 @patch('flask_backend.table_service.get_events_for_reupload')

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -10,11 +10,11 @@ def test_get_table_data(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_table_data('events', 10)
+    rows = ts.get_table_data('events', 10, 2)
 
     mock_get_session.assert_called()
     mock_session.execute.assert_called()
-    assert mock_session.execute.call_args.args[1] == {'limit': 10}
+    assert mock_session.execute.call_args.args[1] == {'limit': 10, 'offset': 2}
     assert rows == [{'id': 1}]
 
 
@@ -26,13 +26,13 @@ def test_get_events_need_packets(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_events_need_packets(5)
+    rows = ts.get_events_need_packets(5, 0)
 
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert "GROUP BY events.id" in str(query)
     assert "JOIN patients" in str(query)
-    assert mock_session.execute.call_args.args[1] == {'status': 'created', 'limit': 5}
+    assert mock_session.execute.call_args.args[1] == {'status': 'created', 'limit': 5, 'offset': 0}
     assert rows == [{'ID': 1}]
 
 
@@ -44,12 +44,12 @@ def test_get_events_for_review(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_events_for_review(6)
+    rows = ts.get_events_for_review(6, 0)
 
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert 'events.status' in str(query)
-    assert mock_session.execute.call_args.args[1] == {'status': 'uploaded', 'limit': 6}
+    assert mock_session.execute.call_args.args[1] == {'status': 'uploaded', 'limit': 6, 'offset': 0}
     assert rows == [{'ID': 2}]
 
 
@@ -61,12 +61,12 @@ def test_get_events_for_reupload(mock_get_session):
     ]
     mock_get_session.return_value = mock_session
 
-    rows = ts.get_events_for_reupload(7)
+    rows = ts.get_events_for_reupload(7, 0)
 
     mock_get_session.assert_called()
     query = mock_session.execute.call_args.args[0]
     assert 'events.status' in str(query)
-    assert mock_session.execute.call_args.args[1] == {'status': 'rejected', 'limit': 7}
+    assert mock_session.execute.call_args.args[1] == {'status': 'rejected', 'limit': 7, 'offset': 0}
     assert rows == [{'ID': 3}]
 
 

--- a/frontend/src/pages/EventUpload.jsx
+++ b/frontend/src/pages/EventUpload.jsx
@@ -3,6 +3,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import DataTable from '../components/DataTable'
 import './EventUpload.css'
 
+const PAGE_SIZE = 20
+
 function EventUpload() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -29,11 +31,15 @@ function EventUpload() {
     noPacketReason === 'Ascertainment diagnosis referred to a prior event'
   const showOtherCause = noPacketReason === 'Other'
 
-  useEffect(() => {
-    fetch(`${API_BASE}/api/events/need_packets`)
+  const fetchPage = (p) => {
+    fetch(`${API_BASE}/api/events/need_packets?limit=${PAGE_SIZE}&offset=${(p - 1) * PAGE_SIZE}`)
       .then((res) => res.json())
       .then((json) => setRows(json.data || []))
       .catch(() => {})
+  }
+
+  useEffect(() => {
+    fetchPage(1)
   }, [API_BASE])
 
   const filteredRows = rows.filter((row) =>
@@ -65,6 +71,7 @@ function EventUpload() {
                 `/events/upload?event_id=${row['ID']}&patient_id=${row['Patient ID']}&date=${row['Date']}&criteria=${encodeURIComponent(row['Criteria'])}`
               )
             }
+            onPageChange={fetchPage}
           />
         </>
       )}


### PR DESCRIPTION
## Summary
- allow DataTable to request pages from the backend
- add `offset` handling in Flask routes and table service
- adjust frontend pages to fetch paged results
- update tests for new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a64fa2114832687df5830bc4c00bf