### PR TITLE
Update deployment URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ DB_NAME=cnics_mci
 DB_USER=mci_user
 DB_PASSWORD=mci_pass
 # Base URL for the backend API used by the React frontend
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
+# Allowed origin for CORS requests to the backend
+FRONTEND_ORIGIN=https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
 # URL to FHIR server used by the application
 FHIR_SERVER=http://example-fhir-server.com
 # Directory containing instruction files to serve via the backend

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository includes a lightweight Docker configuration based on the setup u
 ### Build and Run
 
 1. Copy `.env.example` to `.env` and edit if necessary. `VITE_API_URL` should
-   point at the backend API (defaults to `http://localhost:3001`).
+   point at the backend API (defaults to `https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu`).
 2. Build the Docker images:
 
    ```bash
@@ -32,8 +32,8 @@ This repository includes a lightweight Docker configuration based on the setup u
     docker-compose up
     ```
 
-    The frontend will be served on <http://localhost:3000/> and the backend API
-    on <http://localhost:3001/>.
+    The frontend will be served on <https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu/> and the backend API
+    on <https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu/>.
     The compose file mounts `app/webroot/files` into the backend container so
     instruction documents are available at `/files/<name>`.
 

--- a/default.env
+++ b/default.env
@@ -2,8 +2,8 @@
 # URL to FHIR server used by the application
 FHIR_SERVER=http://example-fhir-server.com
 # Base URL for the backend API used by the React frontend
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
 # Allowed origin for CORS requests to the backend
-FRONTEND_ORIGIN=http://localhost:3000
+FRONTEND_ORIGIN=https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
 # Example URL for an additional database
 EXTERNAL_DB_URL=

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ These steps start the frontend and backend using Docker Compose.
 
 1. Copy `.env.example` to `.env`.
 2. Docker Compose reads variables from `.env` automatically. Run `docker-compose up --build` to build images and start containers.
-3. Open <http://localhost:3000/> in your browser. The backend API will be
-   available at <http://localhost:3001/>.
+3. Open <https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu/> in your browser. The backend API will be
+   available at <https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu/>.
 
 You can stop the containers with `Ctrl+C` or by running `docker-compose down`.

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -11,7 +11,10 @@ from . import table_service
 app = Flask(__name__)
 
 # Enable CORS only for requests coming from the frontend
-allowed_origin = os.getenv("FRONTEND_ORIGIN", "http://localhost:3000")
+allowed_origin = os.getenv(
+    "FRONTEND_ORIGIN",
+    "https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu",
+)
 CORS(
     app,
     resources={r"/api/*": {"origins": allowed_origin}},

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,7 +40,7 @@ docker-compose up web
 ```
 
 When the override file is present the frontend will be available at
-<http://localhost:3000/>.
+<https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu/>.
 
 You can override the `VITE_API_URL` environment variable in the compose file to
 point the frontend to a different backend API.


### PR DESCRIPTION
## Summary
- update default and example env files with prod URLs
- update docs and frontend README for new frontend/backend URLs
- allow CORS from new frontend in Flask app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccb28caa883269b31544a02f320dd