### PR TITLE
Add backend health route and tests

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -244,6 +244,12 @@ def get_file(filename: str):
 # Placeholder for OpenAPI generation scripts
 swagger = None
 
+# Optional root route for basic health check
+@app.route('/')
+def index():
+    """Simple health check route."""
+    return jsonify({'status': 'ok'})
+
 if __name__ == '__main__':
     port = int(os.getenv('PORT', '3000'))
     app.run(host='0.0.0.0', port=port)

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -112,3 +112,10 @@ def test_auth_required_status_summary(mock_service):
     client = app_mod.app.test_client()
     res = client.get('/api/events/status_summary')
     assert res.status_code == 401
+
+
+def test_root_route():
+    client = app.test_client()
+    res = client.get('/')
+    assert res.status_code == 200
+    assert res.get_json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add `/` health endpoint in Flask backend
- test the new health route

## Testing
- `pytest -q`
- `npm install --prefix frontend`
- `npm run build --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_688cd47da1008326a44e11889d5107b1