### PR TITLE
Switch menu dropdowns to hover behavior

### DIFF
--- a/frontend/src/components/MenuBar.css
+++ b/frontend/src/components/MenuBar.css
@@ -5,17 +5,28 @@
   padding: 0;
 }
 
-.menu-bar details summary {
+.menu-bar li {
+  position: relative;
+}
+
+.menu-bar li > span {
   cursor: pointer;
   font-weight: bold;
 }
 
-.menu-bar li details ul {
+.menu-bar li > ul {
+  display: none;
   list-style: none;
   margin: 0.5rem 0 0;
   padding: 0.25rem 0.5rem;
   background: #f8f8f8;
   border: 1px solid #ccc;
   border-radius: 4px;
+  position: absolute;
+  top: 100%;
+  left: 0;
+}
+
+.menu-bar li:hover > ul {
   display: block;
 }

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -1,86 +1,63 @@
 import { Link } from 'react-router-dom'
-import { useEffect, useRef } from 'react'
 import './MenuBar.css'
 
 function MenuBar({ admin, uploader, reviewer }) {
-  const menuRef = useRef(null)
-
-  useEffect(() => {
-    function handleClick(event) {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        menuRef.current
-          .querySelectorAll('details[open]')
-          .forEach((detail) => detail.removeAttribute('open'))
-      }
-    }
-    document.addEventListener('click', handleClick)
-    return () => document.removeEventListener('click', handleClick)
-  }, [])
-
   return (
-    <nav className="menu-bar" ref={menuRef}>
+    <nav className="menu-bar">
       <ul>
         {admin && (
           <li>
-            <details>
-              <summary>Administrative Tools</summary>
-              <ul>
-                <li>
-                  <Link to="/events/viewAll">View all events</Link>
-                </li>
-                <li>
-                  <Link to="/events/add">Add an event</Link>
-                </li>
-                <li>
-                  <Link to="/events/addMany">Add multiple events from a CSV file</Link>
-                </li>
-              </ul>
-            </details>
+            <span>Administrative Tools</span>
+            <ul>
+              <li>
+                <Link to="/events/viewAll">View all events</Link>
+              </li>
+              <li>
+                <Link to="/events/add">Add an event</Link>
+              </li>
+              <li>
+                <Link to="/events/addMany">Add multiple events from a CSV file</Link>
+              </li>
+            </ul>
           </li>
         )}
 
         {admin && (
           <li>
-            <details>
-              <summary>Users</summary>
-              <ul>
-                <li>
-                  <Link to="/users/add">Add a user</Link>
-                </li>
-                <li>
-                  <Link to="/users/viewAll">Edit/Delete users</Link>
-                </li>
-              </ul>
-            </details>
+            <span>Users</span>
+            <ul>
+              <li>
+                <Link to="/users/add">Add a user</Link>
+              </li>
+              <li>
+                <Link to="/users/viewAll">Edit/Delete users</Link>
+              </li>
+            </ul>
           </li>
         )}
 
         {uploader && (
           <li>
-            <details>
-              <summary>Upload Packets</summary>
-              <ul>
-                <li>
-                  <Link to="/events/upload">Upload New Packets</Link>
-                </li>
-                <li>
-                  <Link to="/events/reupload">Re-upload Existing Packets</Link>
-                </li>
-              </ul>
-            </details>
+            <span>Upload Packets</span>
+            <ul>
+              <li>
+                <Link to="/events/upload">Upload New Packets</Link>
+              </li>
+              <li>
+                <Link to="/events/reupload">Re-upload Existing Packets</Link>
+              </li>
+            </ul>
           </li>
         )}
 
         {reviewer && (
           <li>
-            <details>
-              <summary>Reviewer Tools</summary>
-              <ul>
-                <li>
-                  <Link to="/events/review">Review Events</Link>
-                </li>
-              </ul>
-            </details>
+            <span>Reviewer Tools</span>
+            <ul>
+              <li>
+                <Link to="/events/review">Review Events</Link>
+              </li>
+            </ul>
           </li>
         )}
       </ul>


### PR DESCRIPTION
## Summary
- Change menu bar dropdowns from click toggles to CSS hover menus
- Remove JavaScript toggle logic and style submenu on hover

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d7f010588326aff1bd760f9f28fb