### PR TITLE
Remove fixed 100-row limit from backend queries

### DIFF
--- a/flask_backend/README.md
+++ b/flask_backend/README.md
@@ -16,7 +16,7 @@ Run the server:
 python -m flask_backend.app
 ```
 
-The API exposes `/api/tables/<name>` which returns up to 100 rows from the specified table.
+The API exposes `/api/tables/<name>` which returns all rows from the specified table. Results can be limited using optional `limit` and `offset` query parameters.
 
 If the environment variable `KEYCLOAK_REALM` is set, requests are validated
 against a Keycloak server. Configure `KEYCLOAK_URL`, `KEYCLOAK_CLIENT_ID` and

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request, abort, send_from_directory
 from flask_cors import CORS
 import os
+from typing import Optional
 from docx import Document
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
@@ -35,10 +36,11 @@ if not FILES_DIR:
 os.makedirs(FILES_DIR, exist_ok=True)
 
 
-def get_limit(default: int = 100) -> int:
+def get_limit(default: Optional[int] = None) -> Optional[int]:
     """Return the integer limit requested by the client."""
+    value = request.args.get("limit", default)
     try:
-        return int(request.args.get("limit", default))
+        return int(value) if value is not None else None
     except (TypeError, ValueError):
         return default
 

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -19,6 +19,23 @@ def test_get_table_data(mock_get_session):
 
 
 @patch('flask_backend.table_service.models.get_session')
+def test_get_table_data_no_limit(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'id': 1},
+    ]
+    mock_get_session.return_value = mock_session
+
+    rows = ts.get_table_data('events', None, 0)
+
+    query = str(mock_session.execute.call_args.args[0])
+    params = mock_session.execute.call_args.args[1]
+    assert 'LIMIT' not in query.upper()
+    assert params == {}
+    assert rows == [{'id': 1}]
+
+
+@patch('flask_backend.table_service.models.get_session')
 def test_get_events_need_packets(mock_get_session):
     mock_session = MagicMock()
     mock_session.execute.return_value.mappings.return_value.all.return_value = [
@@ -33,6 +50,23 @@ def test_get_events_need_packets(mock_get_session):
     assert "GROUP BY events.id" in str(query)
     assert "JOIN patients" in str(query)
     assert mock_session.execute.call_args.args[1] == {'status': 'created', 'limit': 5, 'offset': 0}
+    assert rows == [{'ID': 1}]
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_events_need_packets_no_limit(mock_get_session):
+    mock_session = MagicMock()
+    mock_session.execute.return_value.mappings.return_value.all.return_value = [
+        {'ID': 1},
+    ]
+    mock_get_session.return_value = mock_session
+
+    rows = ts.get_events_need_packets(None, 0)
+
+    query = str(mock_session.execute.call_args.args[0])
+    params = mock_session.execute.call_args.args[1]
+    assert 'LIMIT' not in query.upper()
+    assert params == {'status': 'created'}
     assert rows == [{'ID': 1}]
 
 


### PR DESCRIPTION
## Summary
- allow unlimited records in API by making limit parameter optional
- build SQL without LIMIT when limit is absent and drop hardcoded limit in patient site lookup
- document optional limit/offset usage and add tests for no-limit behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890de6cb1d08326acddfa331c011d48