### PR TITLE
Implement AJAX user creation form

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -229,6 +229,19 @@ def events_status_summary():
         return jsonify({'error': 'Failed to fetch table data'}), 500
 
 
+@app.route('/api/users', methods=['POST'])
+@requires_auth
+def add_user():
+    """Create a new user."""
+    data = request.get_json() or {}
+    try:
+        user = table_service.create_user(data)
+        return jsonify({'data': user}), 201
+    except Exception:
+        app.logger.exception("Failed to create user")
+        return jsonify({'error': 'Failed to create user'}), 500
+
+
 @app.route('/files/<path:filename>')
 def get_file(filename: str):
     file_path = os.path.join(FILES_DIR, filename)

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -124,3 +124,35 @@ def get_events_with_patient_site():
     for r in rows:
         r["site"] = lookup.get(r["patient_id"])
     return rows
+
+
+def create_user(data: dict) -> dict:
+    """Create a new user record and return the saved fields."""
+    session = get_session()
+    user = models.Users(
+        username=data.get("username"),
+        login=data.get("login"),
+        first_name=data.get("first_name"),
+        last_name=data.get("last_name"),
+        site=data.get("site"),
+        uploader_flag=1 if data.get("uploader") else 0,
+        reviewer_flag=1 if data.get("reviewer") else 0,
+        third_reviewer_flag=1 if data.get("third_reviewer") else 0,
+        admin_flag=1 if data.get("admin") else 0,
+    )
+    session.add(user)
+    session.commit()
+    result = {
+        "id": user.id,
+        "username": user.username,
+        "login": user.login,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "site": user.site,
+        "uploader_flag": user.uploader_flag,
+        "reviewer_flag": user.reviewer_flag,
+        "third_reviewer_flag": user.third_reviewer_flag,
+        "admin_flag": user.admin_flag,
+    }
+    session.close()
+    return result

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -137,3 +137,53 @@ def test_get_events_with_patient_site(mock_get_session, mock_get_external_sessio
     mock_get_session.assert_called()
     mock_get_external_session.assert_called()
     assert rows == [{'id': 1, 'patient_id': 10, 'site': 'UW'}]
+
+
+@patch('flask_backend.table_service.models.Users')
+@patch('flask_backend.table_service.models.get_session')
+def test_create_user(mock_get_session, mock_users):
+    mock_session = MagicMock()
+    mock_get_session.return_value = mock_session
+    user_instance = MagicMock()
+    user_instance.id = 1
+    user_instance.username = 'u'
+    user_instance.login = 'l'
+    user_instance.first_name = 'f'
+    user_instance.last_name = 'l'
+    user_instance.site = 's'
+    user_instance.uploader_flag = 1
+    user_instance.reviewer_flag = 0
+    user_instance.third_reviewer_flag = 0
+    user_instance.admin_flag = 1
+    mock_users.return_value = user_instance
+
+    data = {
+        'username': 'u',
+        'login': 'l',
+        'first_name': 'f',
+        'last_name': 'l',
+        'site': 's',
+        'uploader': True,
+        'reviewer': False,
+        'third_reviewer': False,
+        'admin': True,
+    }
+
+    result = ts.create_user(data)
+
+    mock_get_session.assert_called()
+    mock_session.add.assert_called_with(user_instance)
+    mock_session.commit.assert_called()
+    mock_session.close.assert_called()
+    mock_users.assert_called_with(
+        username='u',
+        login='l',
+        first_name='f',
+        last_name='l',
+        site='s',
+        uploader_flag=1,
+        reviewer_flag=0,
+        third_reviewer_flag=0,
+        admin_flag=1,
+    )
+    assert result['id'] == 1

--- a/frontend/src/pages/UserAdd.jsx
+++ b/frontend/src/pages/UserAdd.jsx
@@ -1,64 +1,120 @@
+import { useState } from 'react'
+
 function UserAdd() {
+  const [formData, setFormData] = useState({
+    username: '',
+    login: '',
+    first_name: '',
+    last_name: '',
+    site: '',
+    uploader: false,
+    reviewer: false,
+    third_reviewer: false,
+    admin: false,
+  })
+  const [status, setStatus] = useState(null)
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const handleChange = (e) => {
+    const { name, type, checked, value } = e.target
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${apiUrl}/api/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(formData),
+      })
+      if (res.ok) {
+        setStatus('saved')
+        setFormData({
+          username: '',
+          login: '',
+          first_name: '',
+          last_name: '',
+          site: '',
+          uploader: false,
+          reviewer: false,
+          third_reviewer: false,
+          admin: false,
+        })
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
   return (
     <div>
       <h1>Add User</h1>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>
             Username:
-            <input type="text" name="username" />
+            <input type="text" name="username" value={formData.username} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Login:
-            <input type="text" name="login" />
+            <input type="text" name="login" value={formData.login} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             First Name:
-            <input type="text" name="first_name" />
+            <input type="text" name="first_name" value={formData.first_name} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Last Name:
-            <input type="text" name="last_name" />
+            <input type="text" name="last_name" value={formData.last_name} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Site:
-            <input type="text" name="site" />
+            <input type="text" name="site" value={formData.site} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Upload packets?
-            <input type="checkbox" name="uploader" />
+            <input type="checkbox" name="uploader" checked={formData.uploader} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Reviewer?
-            <input type="checkbox" name="reviewer" />
+            <input type="checkbox" name="reviewer" checked={formData.reviewer} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Possible 3rd Reviewer?
-            <input type="checkbox" name="third_reviewer" />
+            <input type="checkbox" name="third_reviewer" checked={formData.third_reviewer} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Admin?
-            <input type="checkbox" name="admin" />
+            <input type="checkbox" name="admin" checked={formData.admin} onChange={handleChange} />
           </label>
         </div>
         <button type="submit">Add</button>
       </form>
+      {status === 'saved' && <p>User saved.</p>}
+      {status === 'error' && <p>Failed to save user.</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add service and API route to create users
- build React user creation form that posts via fetch
- cover user creation with unit tests

## Testing
- `npm run lint` *(fails: 'process' is not defined in frontend/vite.config.js)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689382ddaf6483268878ad4fce9a06ad