### PR TITLE
Restore simple menu bar and move admin links

### DIFF
--- a/frontend/src/components/MenuBar.css
+++ b/frontend/src/components/MenuBar.css
@@ -1,32 +1,9 @@
-.menu-bar > ul {
+.menu-bar {
   display: flex;
   gap: 1rem;
-  list-style: none;
-  padding: 0;
 }
 
-.menu-bar li {
-  position: relative;
-}
-
-.menu-bar li > span {
-  cursor: pointer;
+.menu-bar a {
   font-weight: bold;
-}
-
-.menu-bar li > ul {
-  display: none;
-  list-style: none;
-  margin: 0.5rem 0 0;
-  padding: 0.25rem 0.5rem;
-  background: #f8f8f8;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  position: absolute;
-  top: 100%;
-  left: 0;
-}
-
-.menu-bar li:hover > ul {
-  display: block;
+  text-decoration: none;
 }

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -4,63 +4,14 @@ import './MenuBar.css'
 function MenuBar({ admin, uploader, reviewer }) {
   return (
     <nav className="menu-bar">
-      <ul>
-        {admin && (
-          <li>
-            <span>Administrative Tools</span>
-            <ul>
-              <li>
-                <Link to="/events/viewAll">View all events</Link>
-              </li>
-              <li>
-                <Link to="/events/add">Add an event</Link>
-              </li>
-              <li>
-                <Link to="/events/addMany">Add multiple events from a CSV file</Link>
-              </li>
-            </ul>
-          </li>
-        )}
-
-        {admin && (
-          <li>
-            <span>Users</span>
-            <ul>
-              <li>
-                <Link to="/users/add">Add a user</Link>
-              </li>
-              <li>
-                <Link to="/users/viewAll">Edit/Delete users</Link>
-              </li>
-            </ul>
-          </li>
-        )}
-
-        {uploader && (
-          <li>
-            <span>Upload Packets</span>
-            <ul>
-              <li>
-                <Link to="/events/upload">Upload New Packets</Link>
-              </li>
-              <li>
-                <Link to="/events/reupload">Re-upload Existing Packets</Link>
-              </li>
-            </ul>
-          </li>
-        )}
-
-        {reviewer && (
-          <li>
-            <span>Reviewer Tools</span>
-            <ul>
-              <li>
-                <Link to="/events/review">Review Events</Link>
-              </li>
-            </ul>
-          </li>
-        )}
-      </ul>
+      {admin && <Link to="/">Admin Tools</Link>}
+      {uploader && (
+        <>
+          <Link to="/events/upload">Upload New Packets</Link>
+          <Link to="/events/reupload">Re-upload Existing Packets</Link>
+        </>
+      )}
+      {reviewer && <Link to="/events/review">Review Events</Link>}
     </nav>
   )
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import DataTable from '../components/DataTable'
 import './Home.css'
 
@@ -67,6 +67,36 @@ function Home() {
         instructions on the right about how to properly assemble a review
         packet.
       </p>
+
+      <section>
+        <h3>Administrative Tools</h3>
+        <div>
+          <h4>Events</h4>
+          <ul>
+            <li>
+              <Link to="/events/viewAll">View all events</Link>
+            </li>
+            <li>
+              <Link to="/events/add">Add an event</Link>
+            </li>
+            <li>
+              <Link to="/events/addMany">Add multiple events from a CSV file</Link>
+            </li>
+            <li>
+              <a href={`${API_BASE}/api/events/export?format=csv`}>Export all events as CSV</a>
+            </li>
+          </ul>
+          <h4>Users</h4>
+          <ul>
+            <li>
+              <Link to="/users/add">Add a user</Link>
+            </li>
+            <li>
+              <Link to="/users/viewAll">Edit/Delete users</Link>
+            </li>
+          </ul>
+        </div>
+      </section>
 
 
       <section>
@@ -187,7 +217,6 @@ function Home() {
         </ul>
       </div>
 
-      {/* Dropdown menus are now available in the top navigation */}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- revert menu bar to simple button links for Admin Tools, packet upload/reupload, and event review
- list admin event/user links on home page

## Testing
- `npm run lint` *(fails: 'process' is not defined in vite.config.js)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893dfe9e1a483268c2e0f0bf3729734