### PR TITLE
feat: add AJAX form submissions for events

### DIFF
--- a/frontend/src/pages/CriteriaAdd.jsx
+++ b/frontend/src/pages/CriteriaAdd.jsx
@@ -1,28 +1,66 @@
+import { useState } from 'react'
+
 function CriteriaAdd() {
+  const [formData, setFormData] = useState({ event_id: '', name: '', value: '' })
+  const [status, setStatus] = useState(null)
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${apiUrl}/api/criteria`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(formData),
+      })
+      if (res.ok) {
+        setStatus('saved')
+        setFormData({ event_id: '', name: '', value: '' })
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
   return (
     <div>
       <h1>Add Criterion</h1>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>
             Event ID:
-            <input type="text" name="event_id" />
+            <input
+              type="text"
+              name="event_id"
+              value={formData.event_id}
+              onChange={handleChange}
+            />
           </label>
         </div>
         <div>
           <label>
             Name:
-            <input type="text" name="name" />
+            <input type="text" name="name" value={formData.name} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Value:
-            <input type="text" name="value" />
+            <input type="text" name="value" value={formData.value} onChange={handleChange} />
           </label>
         </div>
         <button type="submit">Add</button>
       </form>
+      {status === 'saved' && <p>Criterion saved.</p>}
+      {status === 'error' && <p>Failed to save criterion.</p>}
     </div>
   )
 }

--- a/frontend/src/pages/EventAdd.jsx
+++ b/frontend/src/pages/EventAdd.jsx
@@ -1,40 +1,105 @@
+import { useState } from 'react'
+
 function EventAdd() {
+  const [formData, setFormData] = useState({
+    site_patient_id: '',
+    site: '',
+    event_date: '',
+    criterion_name: '',
+    criterion_value: '',
+  })
+  const [status, setStatus] = useState(null)
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${apiUrl}/api/events`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(formData),
+      })
+      if (res.ok) {
+        setStatus('saved')
+        setFormData({
+          site_patient_id: '',
+          site: '',
+          event_date: '',
+          criterion_name: '',
+          criterion_value: '',
+        })
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
   return (
     <div>
       <h1>Add Event</h1>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>
             Site Patient Id:
-            <input type="text" name="site_patient_id" />
+            <input
+              type="text"
+              name="site_patient_id"
+              value={formData.site_patient_id}
+              onChange={handleChange}
+            />
           </label>
         </div>
         <div>
           <label>
             Site:
-            <input type="text" name="site" />
+            <input type="text" name="site" value={formData.site} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Event Date:
-            <input type="date" name="event_date" />
+            <input
+              type="date"
+              name="event_date"
+              value={formData.event_date}
+              onChange={handleChange}
+            />
           </label>
         </div>
         <div>
           <label>
             Criterion Name:
-            <input type="text" name="criterion_name" />
+            <input
+              type="text"
+              name="criterion_name"
+              value={formData.criterion_name}
+              onChange={handleChange}
+            />
           </label>
         </div>
         <div>
           <label>
             Criterion Value:
-            <input type="text" name="criterion_value" />
+            <input
+              type="text"
+              name="criterion_value"
+              value={formData.criterion_value}
+              onChange={handleChange}
+            />
           </label>
         </div>
         <button type="submit">Add</button>
       </form>
+      {status === 'saved' && <p>Event saved.</p>}
+      {status === 'error' && <p>Failed to save event.</p>}
     </div>
   )
 }

--- a/frontend/src/pages/EventAddMany.jsx
+++ b/frontend/src/pages/EventAddMany.jsx
@@ -1,16 +1,51 @@
+import { useState } from 'react'
+
 function EventAddMany() {
+  const [file, setFile] = useState(null)
+  const [status, setStatus] = useState(null)
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!file) return
+    const form = new FormData()
+    form.append('events_csv', file)
+    try {
+      const res = await fetch(`${apiUrl}/api/events/bulk`, {
+        method: 'POST',
+        credentials: 'include',
+        body: form,
+      })
+      if (res.ok) {
+        setStatus('saved')
+        setFile(null)
+        e.target.reset()
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
   return (
     <div>
       <h1>Add Multiple Events</h1>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>
             CSV File:
-            <input type="file" name="events_csv" />
+            <input
+              type="file"
+              name="events_csv"
+              onChange={(e) => setFile(e.target.files[0])}
+            />
           </label>
         </div>
         <button type="submit">Add</button>
       </form>
+      {status === 'saved' && <p>Events saved.</p>}
+      {status === 'error' && <p>Failed to save events.</p>}
     </div>
   )
 }

--- a/frontend/src/pages/SolicitationAdd.jsx
+++ b/frontend/src/pages/SolicitationAdd.jsx
@@ -1,28 +1,66 @@
+import { useState } from 'react'
+
 function SolicitationAdd() {
+  const [formData, setFormData] = useState({ event_id: '', date: '', contact: '' })
+  const [status, setStatus] = useState(null)
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${apiUrl}/api/solicitations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(formData),
+      })
+      if (res.ok) {
+        setStatus('saved')
+        setFormData({ event_id: '', date: '', contact: '' })
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
   return (
     <div>
       <h1>Add Solicitation</h1>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>
             Event ID:
-            <input type="text" name="event_id" />
+            <input
+              type="text"
+              name="event_id"
+              value={formData.event_id}
+              onChange={handleChange}
+            />
           </label>
         </div>
         <div>
           <label>
             Date:
-            <input type="date" name="date" />
+            <input type="date" name="date" value={formData.date} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Contact:
-            <input type="text" name="contact" />
+            <input type="text" name="contact" value={formData.contact} onChange={handleChange} />
           </label>
         </div>
         <button type="submit">Add</button>
       </form>
+      {status === 'saved' && <p>Solicitation saved.</p>}
+      {status === 'error' && <p>Failed to save solicitation.</p>}
     </div>
   )
 }

--- a/frontend/src/pages/UserEdit.jsx
+++ b/frontend/src/pages/UserEdit.jsx
@@ -1,64 +1,112 @@
+import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
 function UserEdit() {
+  const [searchParams] = useSearchParams()
+  const userId = searchParams.get('id')
+  const [formData, setFormData] = useState({
+    username: '',
+    login: '',
+    first_name: '',
+    last_name: '',
+    site: '',
+    uploader: false,
+    reviewer: false,
+    third_reviewer: false,
+    admin: false,
+  })
+  const [status, setStatus] = useState(null)
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const handleChange = (e) => {
+    const { name, type, checked, value } = e.target
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!userId) {
+      setStatus('error')
+      return
+    }
+    try {
+      const res = await fetch(`${apiUrl}/api/users/${userId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(formData),
+      })
+      setStatus(res.ok ? 'saved' : 'error')
+    } catch {
+      setStatus('error')
+    }
+  }
+
   return (
     <div>
       <h1>Edit User</h1>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>
             Username:
-            <input type="text" name="username" />
+            <input type="text" name="username" value={formData.username} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Login:
-            <input type="text" name="login" />
+            <input type="text" name="login" value={formData.login} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             First Name:
-            <input type="text" name="first_name" />
+            <input type="text" name="first_name" value={formData.first_name} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Last Name:
-            <input type="text" name="last_name" />
+            <input type="text" name="last_name" value={formData.last_name} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Site:
-            <input type="text" name="site" />
+            <input type="text" name="site" value={formData.site} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Upload packets?
-            <input type="checkbox" name="uploader" />
+            <input type="checkbox" name="uploader" checked={formData.uploader} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Reviewer?
-            <input type="checkbox" name="reviewer" />
+            <input type="checkbox" name="reviewer" checked={formData.reviewer} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Possible 3rd Reviewer?
-            <input type="checkbox" name="third_reviewer" />
+            <input type="checkbox" name="third_reviewer" checked={formData.third_reviewer} onChange={handleChange} />
           </label>
         </div>
         <div>
           <label>
             Admin?
-            <input type="checkbox" name="admin" />
+            <input type="checkbox" name="admin" checked={formData.admin} onChange={handleChange} />
           </label>
         </div>
         <button type="submit">Submit</button>
       </form>
+      {status === 'saved' && <p>User updated.</p>}
+      {status === 'error' && <p>Failed to update user.</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add client-side handlers for event creation and bulk upload
- add AJAX submission for criteria, solicitation, and user editing forms

## Testing
- `npm run lint` *(fails: npm: No such file or directory)*
- `/usr/bin/apt-get update` *(fails: missing gpg for repository verification)*

------
https://chatgpt.com/codex/tasks/task_e_6893e012573883268c4d79773d8de4df