### PR TITLE
Add GET events API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See [docs/separation_of_duties.md](docs/separation_of_duties.md) for details on 
 -### Available Endpoints
 
 - `/api/tables/<name>` – return rows from a database table.
+- `/api/events` – events with patient site information.
 - `/api/events/need_packets` – events awaiting packet uploads.
 - `/api/events/for_review` – events with packets ready for review.
 - `/api/events/need_reupload` – events requiring packet re-upload.

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -140,6 +140,32 @@ def get_table(name):
         return jsonify({'error': 'Failed to fetch table data'}), 500
 
 
+@app.route('/api/events')
+@requires_auth
+def get_events():
+    """Events with associated patient site information.
+    ---
+    responses:
+      200:
+        description: Event rows
+        schema:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                type: object
+    """
+    limit = get_limit()
+    offset = get_offset()
+    try:
+        rows = table_service.get_events_with_patient_site(limit, offset)
+        return jsonify({'data': rows})
+    except Exception:
+        app.logger.exception("Failed to fetch event data")
+        return jsonify({'error': 'Failed to fetch event data'}), 500
+
+
 @app.route('/api/events/need_packets')
 @requires_auth
 def events_need_packets():

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -99,11 +99,23 @@ def get_event_status_summary():
     return {row[0]: row[1] for row in rows}
 
 
-def get_events_with_patient_site():
+def get_events_with_patient_site(limit: Optional[int] = None, offset: int = 0):
     """Return events with site info from the external database."""
-    logger.debug("Fetching events with patient site information")
+    logger.debug(
+        "Fetching %sevents with patient site information starting at %d",
+        f"up to {limit} " if limit is not None else "all ",
+        offset,
+    )
     session = get_session()
-    rows = session.execute(text("SELECT id, patient_id FROM events")).mappings().all()
+    stmt = "SELECT id, patient_id FROM events"
+    params = {}
+    if limit is not None:
+        stmt += " LIMIT :limit OFFSET :offset"
+        params.update({"limit": limit, "offset": offset})
+    elif offset:
+        stmt += " LIMIT 18446744073709551615 OFFSET :offset"
+        params["offset"] = offset
+    rows = session.execute(text(stmt), params).mappings().all()
     session.close()
     rows = [dict(r) for r in rows]
 

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -11,6 +11,31 @@ def test_get_table_route(mock_service):
     mock_service.assert_called_with('events', 5, 10)
 
 
+@patch('flask_backend.table_service.get_events_with_patient_site')
+def test_get_events_route(mock_service):
+    mock_service.return_value = [{'id': 1}]
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = None
+    client = app_mod.app.test_client()
+    res = client.get('/api/events?limit=2&offset=0')
+    assert res.status_code == 200
+    assert res.get_json() == {'data': [{'id': 1}]}
+    mock_service.assert_called_with(2, 0)
+
+
+@patch('flask_backend.table_service.get_events_with_patient_site')
+def test_auth_required_events(mock_service):
+    mock_service.return_value = []
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = object()
+    client = app_mod.app.test_client()
+    res = client.get('/api/events')
+    assert res.status_code == 401
+    app_mod.keycloak_openid = None
+
+
 @patch('flask_backend.table_service.get_events_need_packets')
 def test_get_need_packets_route(mock_service):
     mock_service.return_value = [{'ID': 1}]

--- a/openapi.json
+++ b/openapi.json
@@ -17,6 +17,18 @@ paths:
                 type: array
                 items:
                   type: object
+  /api/events:
+    get:
+      responses:
+        '200':
+          description: Event rows
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
   /api/events/need_packets:
     get:
       responses:


### PR DESCRIPTION
## Summary
- expose `/api/events` to list events with patient site info
- support limit/offset in `get_events_with_patient_site`
- document and test new endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68944eded5bc8326b9484231d98e96cd