### PR TITLE
feat: add event creation endpoint

### DIFF
--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -168,6 +168,19 @@ def get_events():
         return jsonify({'error': 'Failed to fetch event data'}), 500
 
 
+@app.route('/api/events', methods=['POST'])
+@requires_auth
+def add_event():
+    """Create a new event."""
+    data = request.get_json() or {}
+    try:
+        event = table_service.create_event(data)
+        return jsonify({'data': event}), 201
+    except Exception:
+        app.logger.exception("Failed to create event")
+        return jsonify({'error': 'Failed to create event'}), 500
+
+
 @app.route('/api/events/need_packets')
 @requires_auth
 def events_need_packets():

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -158,6 +158,31 @@ def test_root_route():
     assert res.get_json() == {'status': 'ok'}
 
 
+@patch('flask_backend.table_service.create_event')
+def test_add_event_route(mock_service):
+    mock_service.return_value = {'id': 1}
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = None
+    client = app_mod.app.test_client()
+    res = client.post('/api/events', json={'site': 'A'})
+    assert res.status_code == 201
+    assert res.get_json() == {'data': {'id': 1}}
+    mock_service.assert_called_with({'site': 'A'})
+
+
+@patch('flask_backend.table_service.create_event')
+def test_auth_required_add_event(mock_service):
+    mock_service.return_value = {}
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = object()
+    client = app_mod.app.test_client()
+    res = client.post('/api/events', json={})
+    assert res.status_code == 401
+    app_mod.keycloak_openid = None
+
+
 @patch('flask_backend.table_service.create_user')
 def test_add_user_route(mock_service):
     mock_service.return_value = {'id': 1}

--- a/openapi.json
+++ b/openapi.json
@@ -29,6 +29,15 @@ paths:
                 type: array
                 items:
                   type: object
+    post:
+      responses:
+        '201':
+          description: Created event
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
   /api/events/need_packets:
     get:
       responses:


### PR DESCRIPTION
## Summary
- support POST /api/events to create events
- document new endpoint in OpenAPI spec
- add tests for event creation and auth guard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894cf3cf8688326b496c4cf4e858a92