### PR TITLE
speckit to remove FHIR server references

### DIFF
--- a/.env.backup
+++ b/.env.backup
@@ -10,7 +10,8 @@
 # VITE_BASE_PATH=/validation-ssingh20/
 
 # FRONTEND_ORIGIN=https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
-# # URL to FHIR server used by the application
+# FHIR_SERVER: not currently used — retained for backward compatibility;
+# no runtime component reads this value.
 # FHIR_SERVER=http://example-fhir-server.com
 # # Directory containing instruction files to serve via the backend
 # FILES_DIR=./app/webroot/files
@@ -48,8 +49,9 @@ VITE_BASE_PATH=/validation-ssingh20/
 FRONTEND_ORIGIN=https://cnics-validation.pm.ssingh20.dev.cirg.uw.edu
 BACKEND_ORIGIN=https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
 
-# URL to FHIR server used by the application
-FHIR_SERVER=http://example-fhir-server.com
+# FHIR_SERVER: not currently used — retained for backward compatibility;
+# no runtime component reads this value.
+#FHIR_SERVER=http://example-fhir-server.com
 
 # Directory containing instruction files to serve via the backend
 FILES_DIR=./app/webroot/files

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@ DB_PASSWORD=mci_pass
 VITE_API_URL=https://backend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
 # Allowed origin for CORS requests to the backend
 FRONTEND_ORIGIN=https://frontend.cnics-validation.pm.ssingh20.dev.cirg.uw.edu
-# URL to FHIR server used by the application
-FHIR_SERVER=http://example-fhir-server.com
+# FHIR_SERVER: not currently used — retained for backward compatibility;
+# no runtime component reads this value.
+#FHIR_SERVER=http://example-fhir-server.com
 # Directory containing instruction files to serve via the backend
 FILES_DIR=./app/webroot/files
 # SQLAlchemy URL for a secondary database (optional)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,5 +22,4 @@ jobs:
           # Set minimal environment variables for testing
           LOG_LEVEL: WARNING
           LOG_FORMAT: TEXT
-          FHIR_SERVER: http://test-server.com
           FRONTEND_ORIGIN: http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# cnics-validation Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-04-14
+
+## Active Technologies
+
+- N/A — no code in a programming language is being + N/A. The repository's runtime stack (Flask + (001-mark-fhir-unused)
+
+## Project Structure
+
+```text
+backend/
+frontend/
+tests/
+```
+
+## Commands
+
+# Add commands for N/A — no code in a programming language is being
+
+## Code Style
+
+N/A — no code in a programming language is being: Follow standard conventions
+
+## Recent Changes
+
+- 001-mark-fhir-unused: Added N/A — no code in a programming language is being + N/A. The repository's runtime stack (Flask +
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ services are built or started. The template defines the following variables:
 - `DB_PASSWORD` – password for `DB_USER`.
 - `VITE_API_URL` – base URL of the backend API (Application Programming Interface) consumed by the React frontend. For unified-domain deployments leave empty to use same-origin.
 - `FRONTEND_ORIGIN` – allowed origin for CORS (Cross‑Origin Resource Sharing) requests to the backend.
-- `FHIR_SERVER` – URL of the FHIR (Fast Healthcare Interoperability Resources) server used by the application.
+- `FHIR_SERVER` – **not currently used.** Retained for backward compatibility with deployments that still set it; no runtime component reads this value. Safe to omit.
 - `FILES_DIR` – directory containing instruction files served by the backend.
 - `DOWNLOADS_DIR` – writable directory where the backend saves generated/downloadable artifacts
   (e.g., uploaded scrubbed ZIPs). Defaults to a subdirectory under `FILES_DIR` if not set.

--- a/default.env
+++ b/default.env
@@ -22,8 +22,9 @@
 ### Variables with VITE_ prefix will be available to the frontend client
 ###
 
-# URL to FHIR server used by the application
-FHIR_SERVER=http://example-fhir-server.com
+# FHIR_SERVER: not currently used — retained for backward compatibility;
+# no runtime component reads this value.
+#FHIR_SERVER=http://example-fhir-server.com
 
 # Allowed origin for CORS requests to the backend
 FRONTEND_ORIGIN=https://frontend.foo.cirg.uw.edu

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
 set -e
 
-# Write environment variables used by the app
-if [ -n "$FHIR_SERVER" ]; then
-  echo "{\"FHIR_SERVER\": \"$FHIR_SERVER\"}" > /var/www/html/env.json
-fi
-
 exec "$@"

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -36,7 +36,7 @@ graph TB
     end
     
     subgraph "External Systems"
-        FHIR[FHIR Server]
+        FHIR[FHIR Server<br/>reserved — not currently used]
         EMAIL[SMTP Server]
         CNICS[CNICS Data Warehouse]
     end
@@ -65,10 +65,6 @@ graph TB
     VTE_BE --> LOGS
     CVA_BE --> LOGS
     
-    MCI_BE --> FHIR
-    VTE_BE --> FHIR
-    CVA_BE --> FHIR
-    
     MCI_BE --> EMAIL
     VTE_BE --> EMAIL
     CVA_BE --> EMAIL
@@ -77,6 +73,13 @@ graph TB
     VTE_DB --> CNICS
     CVA_DB --> CNICS
 ```
+
+> **Note on the FHIR Server node:** The FHIR node above is retained as a
+> reserved placeholder only. It is **not currently used** — retained for
+> backward compatibility; no runtime component reads this value, and no
+> study backend currently calls a FHIR server. The node is intentionally
+> drawn without edges to make that visually obvious. Any future FHIR
+> integration will be tracked as its own feature with its own spec.
 
 ## 2. Study Configuration Loading
 

--- a/specs/001-mark-fhir-unused/checklists/requirements.md
+++ b/specs/001-mark-fhir-unused/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Mark FHIR Server References as Not Currently Used
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Validation performed on initial draft; all items pass.
+- Scope explicitly covers documentation, config templates, CI workflow, and
+  container entrypoint only. Runtime code is excluded because a repo-wide
+  search confirmed no Python or JavaScript code consumes `FHIR_SERVER`.

--- a/specs/001-mark-fhir-unused/contracts/fhir-env-var.md
+++ b/specs/001-mark-fhir-unused/contracts/fhir-env-var.md
@@ -1,0 +1,59 @@
+# Contract Note: `FHIR_SERVER` environment variable
+
+**Feature**: 001-mark-fhir-unused
+**Contract type**: environment variable / configuration surface
+**Status**: inert (not currently used)
+
+## What changes
+
+This feature does not modify any HTTP API, CLI, or inter-service contract.
+It updates the *configuration contract* exposed by the repository's
+environment-variable templates so that the `FHIR_SERVER` variable is
+documented as inert.
+
+## Pre-feature contract
+
+> `FHIR_SERVER` — URL of the FHIR server used by the application.
+
+This phrasing implied the variable was required for "the application" to
+function, which is false.
+
+## Post-feature contract
+
+> `FHIR_SERVER` — **not currently used.** Retained for backward
+> compatibility with deployments that still set it. No runtime component
+> reads this value. Safe to omit.
+
+## Compatibility guarantees
+
+- **Unset**: the application stack starts successfully. CI passes
+  successfully. No warnings or errors are emitted.
+- **Set to any string (including empty, malformed URLs, or real FHIR
+  endpoints)**: the application stack behaves identically to the unset
+  case. The value is neither validated nor read.
+- **Set to a value that was previously working for a downstream
+  deployment**: no change. The variable has always been inert; the only
+  change here is that its inert status is now documented.
+
+## Test matrix
+
+| Input                                | Expected outcome                    |
+|--------------------------------------|-------------------------------------|
+| `FHIR_SERVER` unset                  | Stack starts; CI passes.            |
+| `FHIR_SERVER=""`                     | Stack starts; CI passes.            |
+| `FHIR_SERVER=http://test-server.com` | Stack starts; CI passes (baseline). |
+| `FHIR_SERVER=garbage`                | Stack starts; CI passes.            |
+
+All four cases produce identical runtime behavior because no code reads
+the variable. The matrix is documentary — we are not introducing new
+tests, because introducing a test for "this variable is ignored" would
+ossify the inertness and make a future revival harder.
+
+## Non-goals
+
+- Removing `FHIR_SERVER` from downstream deployments' real `.env` files.
+  That is a deployment-operator concern and out of scope for this repo.
+- Introducing a FHIR integration. If one is ever needed, it should be
+  planned as a separate feature with its own spec.
+- Deprecating the variable name. "Deprecation" implies we are preparing
+  to remove it; we are not. The variable is simply not currently used.

--- a/specs/001-mark-fhir-unused/data-model.md
+++ b/specs/001-mark-fhir-unused/data-model.md
@@ -1,0 +1,41 @@
+# Phase 1 Data Model: Mark FHIR Server References as Not Currently Used
+
+**Feature**: 001-mark-fhir-unused
+**Date**: 2026-04-14
+
+This feature does not add, remove, or modify any database tables,
+SQLAlchemy models, or persisted entities. The only "entity" it touches is
+a single environment variable that is not read by any runtime code.
+
+## Entities
+
+### `FHIR_SERVER` (environment variable)
+
+- **Kind**: dotenv / shell environment variable, string type, optional.
+- **Current producer surfaces**: `.env.example`, `default.env`,
+  `.env.backup`, `README.md` (documentation), `.github/workflows/tests.yml`
+  (CI injection), `docker-entrypoint.sh` (container pass-through).
+- **Current consumer surfaces**: **none**. Verified by case-insensitive
+  search across `flask_backend/` and `frontend/`.
+- **Validation rules**:
+  - Optional: no code path requires a value.
+  - Unvalidated: no format, URL, or reachability check is performed.
+- **State transitions**: none. The variable is read-only configuration.
+- **Post-feature state**: the variable remains declared nowhere by
+  default (templates comment it out), is tolerated if a deployment sets
+  it, and is documented everywhere as "not currently used — retained
+  for backward compatibility; no runtime component reads this value."
+
+## Database model impact
+
+None. No tables, columns, migrations, or views are affected.
+
+## Frontend model impact
+
+None. No React components, Redux/Zustand slices, or API clients are
+affected.
+
+## Contracts impact
+
+See `contracts/fhir-env-var.md` for the single contract note describing
+the variable's "inert pass-through" status.

--- a/specs/001-mark-fhir-unused/plan.md
+++ b/specs/001-mark-fhir-unused/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Mark FHIR Server References as Not Currently Used
+
+**Branch**: `001-mark-fhir-unused` | **Date**: 2026-04-14 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-mark-fhir-unused/spec.md`
+
+## Summary
+
+No runtime code in this repository reads or consumes the `FHIR_SERVER`
+environment variable, yet the variable is advertised in environment
+templates, described in the README, drawn into the technical architecture
+diagram, injected by CI, and propagated by the container entrypoint. This
+feature edits those seven locations so the "not currently used" status is
+obvious to contributors, architects, and operators, without breaking any
+deployment that still sets the variable.
+
+Technical approach: a purely editorial change. No Python, JavaScript, SQL,
+or container-image changes. Each touched file is either annotated in place
+("reserved / not currently used") or has its FHIR block removed, with the
+choice made per-file in Phase 0. The CI workflow is altered to confirm the
+stack passes tests with `FHIR_SERVER` unset.
+
+## Technical Context
+
+**Language/Version**: N/A — no code in a programming language is being
+modified. The touched artifacts are Markdown, dotenv config, a shell
+script, and a GitHub Actions YAML workflow.
+**Primary Dependencies**: N/A. The repository's runtime stack (Flask +
+SQLAlchemy backend, React/Vite frontend, MariaDB, Docker Compose) is
+unchanged by this feature.
+**Storage**: N/A. No database, schema, or file-system layout changes.
+**Testing**: Manual verification via (a) local Docker Compose smoke test
+with `FHIR_SERVER` unset, and (b) one CI run on this branch with the
+`FHIR_SERVER` env entry removed from `.github/workflows/tests.yml`. The
+existing `pytest flask_backend/tests/` suite is the regression net — no
+new tests are added because no behavior is changing.
+**Target Platform**: Linux / Docker Compose, same as the rest of the
+repository. No platform-specific considerations.
+**Project Type**: Documentation + configuration change in an existing web
+application (Flask backend + React frontend). The surrounding project is
+"web application" per the template taxonomy; this feature itself ships no
+application code.
+**Performance Goals**: N/A. Zero runtime impact.
+**Constraints**: Must not break any deployment that currently sets
+`FHIR_SERVER` — see Principle III in the constitution. Must keep the
+variable harmless as a pass-through; it MAY be removed from templates and
+CI but MUST continue to be tolerated if present in a real `.env`.
+**Scale/Scope**: Seven files to edit (see Source Code section below). Zero
+new files of project code. The only new files are the spec-kit
+artifacts under `specs/001-mark-fhir-unused/`.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Principles evaluated against `.specify/memory/constitution.md` v1.0.0:
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Single Codebase, Many Studies | ✅ PASS | Edits apply uniformly to shared files. No per-study forks introduced. |
+| II. Study Data Isolation | ✅ PASS | No data access, DB, or auth changes. |
+| III. Backwards Compatibility With Legacy Data | ✅ PASS | Deployments that still set `FHIR_SERVER` remain functional; the variable is inert today and stays inert after the change. No schema, API, or lifecycle changes. |
+| IV. Configuration Over Code Forks | ✅ PASS | Change removes a dormant configuration artifact; no new per-study `if` chains introduced. |
+| V. Workflow and Role Parity | ✅ PASS | No lifecycle, role, or auth changes. |
+
+Security & Data Governance: unchanged. Development Workflow & Quality Gates:
+the change is scoped to documentation, templates, CI, and an entrypoint
+script; PR description will note it affects all studies' shared config.
+
+**Result**: Initial gate PASSED. No complexity justifications required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-mark-fhir-unused/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — per-file retain-vs-remove decisions
+├── data-model.md        # Phase 1 output — minimal: single config variable
+├── quickstart.md        # Phase 1 output — local verification recipe
+├── contracts/           # Phase 1 output — env-var contract note
+│   └── fhir-env-var.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command — NOT created here)
+```
+
+### Source Code (repository root)
+
+This feature edits existing files only; no new directories or modules are
+created. Seven files in scope:
+
+```text
+README.md                           # line 50 — FHIR env var description
+.env.example                        # lines 9–10 — FHIR_SERVER entry
+default.env                         # lines 25–26 — FHIR_SERVER entry
+.env.backup                         # lines 13–14 (commented) and 51–52 (active)
+docs/technical-architecture.md      # line 39 (graph node) and 68–70 (edges)
+docker-entrypoint.sh                # lines 5–7 — FHIR env.json pass-through
+.github/workflows/tests.yml         # line 25 — FHIR_SERVER injected into pytest env
+```
+
+Runtime code directories (`flask_backend/`, `frontend/`) were searched and
+contain zero references to `fhir` or `FHIR_SERVER`. They are out of scope.
+
+**Structure Decision**: No new structure. The repository's existing web
+application layout (Flask backend under `flask_backend/`, React frontend
+under `frontend/`, configuration templates at the repo root, docs under
+`docs/`, CI under `.github/workflows/`) stays as-is. This feature is an
+in-place edit of seven existing files.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified.**
+
+None. The Constitution Check passed without reservations.

--- a/specs/001-mark-fhir-unused/quickstart.md
+++ b/specs/001-mark-fhir-unused/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart: Verifying the FHIR "not currently used" Change
+
+**Feature**: 001-mark-fhir-unused
+**Audience**: the engineer implementing this feature, and reviewers
+
+This quickstart is the verification recipe for the change. It replaces a
+traditional test suite because no runtime behavior is changing — the goal
+is to prove that nothing broke *and* that the documentation is now
+internally consistent.
+
+## Prerequisites
+
+- Local Docker Compose working copy of this branch.
+- A `.env` file derived from the post-change `.env.example`.
+
+## 1. Consistency check (documentation)
+
+From the repo root:
+
+```bash
+grep -rni 'fhir' --include='*.md' --include='*.env*' --include='*.yml' \
+  --include='*.sh' .
+```
+
+Expected outcome:
+
+- Every hit falls into one of two categories:
+  1. A retained reference that includes the canonical phrase
+     **"not currently used"** (variants in `README.md`, `.env.example`,
+     `default.env`, `.env.backup`, `docs/technical-architecture.md`).
+  2. An intentional absence — `docker-entrypoint.sh` and
+     `.github/workflows/tests.yml` should produce **zero** hits because
+     their FHIR blocks were removed.
+- No hit exists anywhere that implies FHIR is a live runtime dependency.
+
+If a new file is introduced during development that mentions FHIR, it
+MUST use the canonical wording from `research.md`.
+
+## 2. Local startup check (unset `FHIR_SERVER`)
+
+```bash
+# Start from a fresh environment file with no FHIR entry
+cp .env.example .env
+grep -i fhir .env   # should print nothing (entry is commented out)
+
+docker-compose build
+docker-compose up -d
+docker-compose ps
+```
+
+Expected outcome:
+
+- All services become healthy.
+- `docker-compose logs backend` shows no warnings or errors related to
+  FHIR, environment variables, or missing configuration.
+- The frontend loads in a browser at the configured origin.
+- Log in as a test user and navigate to the events list. Confirm the
+  primary validation workflow (list events, open an event, view a
+  review) works identically to a pre-change run.
+
+## 3. Local startup check (explicit `FHIR_SERVER` set)
+
+This verifies the backward-compatibility promise from the contract.
+
+```bash
+# Temporarily add FHIR_SERVER to .env
+echo 'FHIR_SERVER=http://legacy-value.example.com' >> .env
+
+docker-compose down
+docker-compose up -d
+docker-compose logs backend | grep -i fhir   # should print nothing
+```
+
+Expected outcome:
+
+- Stack starts successfully.
+- No backend logs mention FHIR.
+- The application behaves identically to the unset case.
+
+Remove the temporary line after the check:
+
+```bash
+sed -i '/^FHIR_SERVER=/d' .env
+```
+
+## 4. CI check (GitHub Actions)
+
+Push this branch to the remote. Open the Actions tab and watch the
+`Python Tests` workflow run.
+
+Expected outcome:
+
+- Workflow passes without the `FHIR_SERVER` env entry in
+  `.github/workflows/tests.yml`.
+- `pytest flask_backend/tests/ -v` completes with the same pass count as
+  on `main` (no new tests added, no existing tests regressed).
+
+If any test fails with a stack trace referencing FHIR, the research
+assumption (no runtime consumer) was wrong — stop and revisit
+`research.md` before merging.
+
+## 5. Architecture diagram spot-check
+
+Render `docs/technical-architecture.md` (GitHub, VS Code preview, or
+any Markdown viewer with Mermaid support).
+
+Expected outcome:
+
+- The "Detailed System Architecture" diagram still contains a FHIR node
+  under "External Systems," but:
+  - Its label reads `reserved — not currently used`.
+  - No arrows connect any study backend (`MCI_BE`, `VTE_BE`, `CVA_BE`)
+    to the FHIR node.
+- A short paragraph below the diagram explains the FHIR node is
+  reserved and that no runtime component currently calls it.
+
+## Rollback
+
+The change is a handful of documentation and config edits. If anything
+goes wrong, revert the branch with `git revert`. No database migrations,
+feature flags, or staged rollouts are involved.

--- a/specs/001-mark-fhir-unused/research.md
+++ b/specs/001-mark-fhir-unused/research.md
@@ -1,0 +1,166 @@
+# Phase 0 Research: Mark FHIR Server References as Not Currently Used
+
+**Feature**: 001-mark-fhir-unused
+**Date**: 2026-04-14
+
+## Scope of research
+
+The feature has no open `NEEDS CLARIFICATION` markers and no new
+dependencies to evaluate. The only real design decision is, for each of
+the seven files that mentions `FHIR_SERVER`, whether to:
+
+- **Annotate**: leave the reference in place and add an in-line comment
+  explaining it is not currently used, or
+- **Remove**: delete the FHIR block entirely.
+
+This research section records that per-file decision plus supporting
+evidence.
+
+## Shared facts (apply to every decision below)
+
+- **Decision**: `FHIR_SERVER` is consumed by zero lines of Python or
+  JavaScript in this repository.
+  **Rationale**: Verified by two case-insensitive searches:
+  1. `flask_backend/` — 0 matches for `fhir`
+  2. `frontend/` — 0 matches for `fhir`
+  **Alternatives considered**: None; a negative search result is
+  dispositive.
+
+- **Decision**: `docker-entrypoint.sh` writes `/var/www/html/env.json`
+  containing the FHIR value, but nothing reads that file.
+  **Rationale**: Verified by a repo-wide search for `env.json` — the only
+  match is `docker-entrypoint.sh` itself. No frontend bundle, backend
+  handler, or build step consumes it.
+  **Alternatives considered**: Keeping the pass-through "just in case" was
+  considered and rejected — it is a maintenance trap because a reader of
+  the entrypoint script reasonably assumes the file is consumed.
+
+- **Decision**: A deployment somewhere in the wild may still set
+  `FHIR_SERVER` in its real `.env` file.
+  **Rationale**: The variable has existed since the CakePHP migration
+  baseline; we cannot audit downstream deployments.
+  **Alternatives considered**: Requiring downstream deployments to unset
+  it was rejected because it would break Principle III (backward
+  compatibility). The chosen approach tolerates the variable silently.
+
+## Per-file decisions
+
+### 1. `.env.example` — copied by every new contributor
+
+- **Decision**: Retain the variable, commented out, with a
+  "not currently used" note. Keep the example URL value on a commented
+  line so it is obvious the entry exists for historical reasons.
+- **Rationale**: This file is the primary onboarding touchpoint. Removing
+  the entry would erase the context and make a future reader think FHIR
+  was never part of this project. Annotating in place directly serves
+  User Story 1 (P1).
+- **Alternatives considered**: Full removal (rejected — loses context);
+  leaving uncommented with a trailing `# unused` comment (rejected — the
+  value of a commented entry is unambiguous, whereas a trailing comment
+  is easy to overlook).
+
+### 2. `default.env` — documented defaults
+
+- **Decision**: Same treatment as `.env.example`: comment out the entry
+  and add a "not currently used" header comment. Adjacent explanatory
+  comment is updated to match.
+- **Rationale**: `default.env` is the docs-facing companion to
+  `.env.example`. Keeping the two in visual lockstep avoids the bug where
+  a reader treats one as authoritative over the other.
+- **Alternatives considered**: Deleting (rejected — same context loss
+  argument).
+
+### 3. `.env.backup` — historical snapshot
+
+- **Decision**: Annotate both the already-commented block (lines 13–14)
+  and the currently-active block (lines 51–52) with a "not currently
+  used" note. Prefer annotation over removal because this file is a
+  snapshot-style backup and deleting lines would mask what that snapshot
+  looked like.
+- **Rationale**: Backup files are most useful when they faithfully
+  represent a point-in-time state. Removing entries defeats that
+  purpose; annotation satisfies FR-008 (consistent wording) without
+  rewriting history.
+- **Alternatives considered**: Deleting the entire `.env.backup` file
+  (rejected — out of scope for this feature; if the file is genuinely
+  dead it should be removed in a separate cleanup PR).
+
+### 4. `README.md` — the project README's env var list
+
+- **Decision**: Replace the existing one-line description with one that
+  explicitly says the variable is not currently used by any runtime
+  component, and notes that the entry is retained for backward
+  compatibility with deployments that still set it.
+- **Rationale**: README is the most-read document in the repo. Principle
+  III means we cannot promise to delete the variable, so the README must
+  describe the *actual* current state.
+- **Alternatives considered**: Deleting the README bullet (rejected —
+  readers searching for "FHIR" in the README would find nothing and
+  wonder why `.env.example` mentions it).
+
+### 5. `docs/technical-architecture.md` — diagram + edges
+
+- **Decision**: Keep the `FHIR[FHIR Server]` node in the Mermaid diagram
+  but rename its label to `FHIR[FHIR Server<br/>reserved — not currently used]`,
+  and remove the three `*_BE --> FHIR` edges so the diagram no longer
+  depicts an active dependency. Add a one-paragraph note under the
+  diagram stating the node is reserved for a potential future
+  integration and that no current runtime component calls it.
+- **Rationale**: Preserves historical context for future revivers while
+  removing the phantom-dependency misread that User Story 2 is written
+  against. Dropping the edges is the key signal — a disconnected node
+  reads as "not wired up."
+- **Alternatives considered**:
+  (a) Deleting the node outright — rejected because the revival context
+  is useful.
+  (b) Keeping the edges but adding a legend — rejected because diagram
+  legends are routinely skimmed past; the visual signal (no edges) is
+  more reliable.
+
+### 6. `docker-entrypoint.sh` — env.json pass-through
+
+- **Decision**: Remove the FHIR block entirely (lines 4–7). No annotation
+  left behind; the commit message and this research doc provide the
+  historical record.
+- **Rationale**: The block writes a file that nothing reads. Under
+  Principle IV (configuration over code forks) and the constitution's
+  "Don't add error handling, fallbacks, or validation for scenarios that
+  can't happen" ethos, dead code should be deleted rather than
+  preserved. The entrypoint script is internal machinery, not a
+  user-facing reference, so there is no onboarding-context argument for
+  retention.
+- **Alternatives considered**: Keeping the block with a comment
+  (rejected — the block writes a file that nothing reads; leaving it
+  suggests something depends on `env.json`, which is misleading).
+
+### 7. `.github/workflows/tests.yml` — CI env injection
+
+- **Decision**: Remove the `FHIR_SERVER: http://test-server.com` line
+  from the `env:` block. Do not annotate in place; the absence after this
+  PR is the signal.
+- **Rationale**: The variable is not read by any test. A workflow env
+  block should reflect the actual inputs a test needs; stale entries
+  confuse future maintainers. This directly satisfies SC-004 (CI passes
+  without `FHIR_SERVER`).
+- **Alternatives considered**: Keeping it with a YAML comment (rejected
+  for the same reason as the entrypoint — CI files are internal
+  machinery, and a stale env entry is a bigger trap than a clean one).
+
+## Wording standard (for FR-008 consistency)
+
+All retained annotations MUST use the same canonical phrase:
+
+> **"not currently used — retained for backward compatibility; no
+> runtime component reads this value."**
+
+Where space is tight (e.g., inside a Mermaid node label), a shortened
+form is acceptable:
+
+> **"reserved — not currently used"**
+
+This pair of phrases is the authoritative vocabulary for this feature.
+
+## Open questions
+
+None. All Phase 0 decisions are settled and can be implemented without
+further clarification.

--- a/specs/001-mark-fhir-unused/spec.md
+++ b/specs/001-mark-fhir-unused/spec.md
@@ -1,0 +1,227 @@
+# Feature Specification: Mark FHIR Server References as Not Currently Used
+
+**Feature Branch**: `001-mark-fhir-unused`
+**Created**: 2026-04-14
+**Status**: Draft
+**Input**: User description: "This code references a FHIR server in several places, however there is no current need for it... Make edits to indicate that it's not currently used."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - New Contributor Reading Configuration (Priority: P1)
+
+A new contributor clones the repository, copies `.env.example` to `.env`, and
+reads the README to figure out which environment variables they must set to
+run the stack locally. Today, the FHIR server variable is listed alongside
+database and file-path variables with no indication that it is dormant, so
+contributors either hunt for a working FHIR URL, point it at a stranger's
+server, or waste time tracing its usage through the codebase before
+discovering nothing consumes it.
+
+**Why this priority**: This is the highest-friction path. Onboarding and
+local-dev setup touch these files first, and the confusion compounds because
+the variable sits in the "required" visual group. Fixing the docs and
+examples immediately removes the trap.
+
+**Independent Test**: A contributor who has never seen this repo reads
+`README.md` and `.env.example`, and can state without ambiguity that they do
+not need to provide a FHIR server value to run the application. Verified by
+asking a fresh reviewer to list required vs. optional env vars and confirming
+they classify FHIR as "not currently used."
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh clone of the repository, **When** a contributor reads
+   `.env.example`, **Then** the FHIR server entry is clearly labeled as not
+   currently used and does not appear to be a required setting.
+2. **Given** a contributor reading `README.md`'s environment variables
+   section, **When** they encounter the FHIR entry, **Then** the description
+   explicitly states the value is inert in the current codebase and lists no
+   behavior that depends on it.
+3. **Given** a contributor running the local development stack with the FHIR
+   value left blank or removed, **When** the application starts, **Then** the
+   application behaves identically to a run with the placeholder value set.
+
+---
+
+### User Story 2 - Architecture Doc Reader (Priority: P2)
+
+A stakeholder (maintainer, reviewer, new team member, or auditor) reads
+`docs/technical-architecture.md` to understand the system's runtime
+dependencies and finds a "FHIR Server" box wired into multiple study
+backends in a diagram. They reasonably conclude the system depends on an
+external FHIR service, which is misleading because no runtime code actually
+calls one.
+
+**Why this priority**: Architecture docs shape decisions about deployment,
+security review, and compliance scope. A phantom dependency can distort
+those decisions (e.g., unnecessary network allowlisting, spurious
+compliance concerns) even if it never breaks a build.
+
+**Independent Test**: A reader of the architecture doc can accurately answer
+"does this system currently talk to a FHIR server?" with "no, the reference
+is historical / reserved for future use."
+
+**Acceptance Scenarios**:
+
+1. **Given** the technical architecture diagram, **When** a reader views the
+   FHIR node, **Then** it is visually and textually marked as not currently
+   in use (e.g., labeled "reserved / not currently used") or removed from
+   the active-dependency view.
+2. **Given** the architecture narrative, **When** FHIR is mentioned, **Then**
+   the text states explicitly that no current runtime component calls a FHIR
+   server and clarifies whether the reference is reserved for future work or
+   purely historical.
+
+---
+
+### User Story 3 - CI/Deployment Operator (Priority: P3)
+
+An operator maintaining CI (Continuous Integration) pipelines or preparing a
+new study deployment reviews workflow files and deployment scripts. They see
+`FHIR_SERVER` threaded into CI test environments and the container entrypoint
+and assume it must be provided for the stack to boot or for tests to pass.
+
+**Why this priority**: CI and deploy flows already work without a real FHIR
+server (the test workflow uses a placeholder URL), so the risk here is
+wasted effort rather than broken pipelines. Still, leaving the variable in
+these files without comment perpetuates the misunderstanding each time
+someone copies or adapts them for a new study.
+
+**Independent Test**: An operator reading the CI workflow and container
+entrypoint can correctly state that `FHIR_SERVER` has no functional effect
+and that omitting it will not break tests or container startup.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CI workflow file, **When** an operator inspects the env
+   block, **Then** the FHIR entry is either removed or annotated as not
+   currently used.
+2. **Given** the container entrypoint script, **When** an operator reads the
+   FHIR handling block, **Then** the behavior is documented as a dormant
+   pass-through that does not affect runtime behavior, or the block is
+   removed.
+3. **Given** a new study deployment prepared from the default configuration
+   templates, **When** the operator omits any FHIR value, **Then** the stack
+   starts and passes CI without warnings about the missing variable.
+
+---
+
+### Edge Cases
+
+- A historical deployment somewhere still sets `FHIR_SERVER` in its real
+  environment file. The change must not cause that deployment to fail, even
+  though the value is now documented as inert.
+- A reader searches the repository for "FHIR" expecting to find runtime
+  behavior. The remaining references must consistently point them to the
+  "not currently used" explanation rather than suggesting live integration.
+- A future feature genuinely needs a FHIR integration. The change must not
+  destroy context so thoroughly that reviving FHIR support requires
+  archaeology; the rationale for keeping or removing the placeholder should
+  be discoverable.
+- A downstream fork or sibling repo (e.g., a study-specific deployment) may
+  have copied `.env.example` or `default.env`. The change must flag the
+  variable clearly enough that maintainers of those copies notice it on the
+  next pull.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All repository-level environment variable templates
+  (`.env.example`, `default.env`, and any archived copies such as
+  `.env.backup`) MUST clearly indicate that the FHIR server variable is not
+  currently used by any runtime component.
+- **FR-002**: The project README's environment variables section MUST
+  describe the FHIR server variable as not currently used and MUST NOT imply
+  it is required for the application to function.
+- **FR-003**: The technical architecture documentation MUST NOT depict the
+  FHIR server as an active runtime dependency of any study backend. If
+  retained in the diagram or narrative, it MUST be explicitly annotated as
+  reserved / not currently used.
+- **FR-004**: The CI workflow that injects a placeholder FHIR URL MUST
+  either remove the variable or annotate it as not currently used, so
+  future maintainers of the workflow understand it is non-functional.
+- **FR-005**: The container entrypoint handling of the FHIR variable MUST
+  either be removed or documented (in the script itself) as a dormant
+  pass-through that has no effect on runtime behavior.
+- **FR-006**: Running the application stack locally MUST succeed when no
+  value is provided for the FHIR server variable. Omitting it MUST NOT
+  produce errors, warnings, or failed health checks.
+- **FR-007**: CI runs MUST succeed when the FHIR environment variable is
+  not set. No test MUST depend on its presence or its value.
+- **FR-008**: The set of updated files MUST use consistent wording for the
+  "not currently used" status, so a reader searching the repository finds
+  the same explanation regardless of which file they land on first.
+- **FR-009**: The change MUST NOT delete any FHIR-related runtime code,
+  because none exists. This requirement is stated explicitly so the review
+  scope stays limited to documentation, configuration templates, CI, and
+  deployment scripts.
+- **FR-010**: If the FHIR variable is retained anywhere (rather than
+  removed), the retained reference MUST include, in-line, the reason it is
+  being kept (e.g., "reserved for future integration" or "kept for backward
+  compatibility with deployments that still set it").
+
+### Key Entities
+
+- **FHIR Server Environment Variable (`FHIR_SERVER`)**: A string value
+  representing the URL of an external FHIR service. Currently declared in
+  configuration templates, surfaced in documentation, and passed through
+  CI and the container entrypoint, but not consumed by any backend or
+  frontend runtime code.
+- **Environment Variable Templates**: Files that contributors and
+  operators copy when preparing a new environment. Their primary job is to
+  communicate which variables matter and how to set them.
+- **Architecture Documentation**: Diagrams and narrative that shape
+  stakeholders' mental model of runtime dependencies and deployment scope.
+- **CI / Deployment Scripts**: Workflow files and container entrypoints
+  that propagate environment variables into running jobs and containers.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A contributor new to the repository can correctly classify
+  the FHIR variable as "not currently used" within 60 seconds of opening
+  either `.env.example` or the README environment variables section —
+  without reading any source code.
+- **SC-002**: 100% of repository files that mention FHIR communicate the
+  same status ("not currently used"), verified by reading each hit from a
+  case-insensitive search for "fhir" across the repository.
+- **SC-003**: The local development stack starts successfully with the
+  FHIR variable unset, demonstrated by a clean startup run and a smoke
+  test of the primary application workflow.
+- **SC-004**: The CI workflow passes without the FHIR variable being
+  injected, demonstrated by one successful CI run with the value removed
+  from the workflow's env block.
+- **SC-005**: Zero runtime behavior changes: the set of features available
+  to reviewers, uploaders, and admins before and after the change is
+  identical, verified by a walk-through of the primary validation
+  workflow on a running deployment.
+- **SC-006**: Time spent by future contributors investigating whether
+  FHIR is a real dependency trends to zero, measured by the absence of
+  new questions or issues about FHIR configuration following the change.
+
+## Assumptions
+
+- No backend or frontend code currently reads, calls, or depends on a FHIR
+  server. A repository-wide search confirmed references exist only in
+  configuration templates, documentation, the CI workflow, and the
+  container entrypoint.
+- The project does not have an active roadmap item that requires a FHIR
+  integration in the near term. If one exists, this change is still
+  correct (it marks today's reality) but the retained references should
+  include that context.
+- Downstream deployments that set `FHIR_SERVER` in their private
+  environment files will continue to function unchanged; the variable is
+  passed through harmlessly today and will remain harmless after this
+  change.
+- "Mark as not currently used" is preferred over wholesale removal for at
+  least the most visible references (README, architecture doc), because
+  the historical context is useful for reviewers deciding whether to
+  revive FHIR support later. Purely internal references (CI env block,
+  entrypoint pass-through) MAY be removed outright at the implementer's
+  discretion, provided the resulting state still satisfies the functional
+  requirements above.
+- The constitution's backwards-compatibility principle (Principle III)
+  applies: this change must not break any existing deployment that
+  currently sets `FHIR_SERVER`, even though the variable is inert.

--- a/specs/001-mark-fhir-unused/tasks.md
+++ b/specs/001-mark-fhir-unused/tasks.md
@@ -1,0 +1,266 @@
+---
+
+description: "Task list for feature 001-mark-fhir-unused"
+---
+
+# Tasks: Mark FHIR Server References as Not Currently Used
+
+**Input**: Design documents from `/specs/001-mark-fhir-unused/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: The feature specification does not request automated tests, and
+this is a documentation/configuration-only change with zero runtime code
+impact. No test tasks are included. Verification is performed manually
+using `quickstart.md`.
+
+**Organization**: Tasks are grouped by user story so each story can be
+landed and verified independently. Because this feature edits seven
+existing files with no new code, the Setup and Foundational phases are
+minimal.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are included in every implementation task
+
+## Path Conventions
+
+This feature has no new source paths. All edits target existing files at
+their current locations in the repository root, `docs/`, `.github/`, and
+the repo-level dotenv files.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the canonical wording the rest of the feature will
+reuse. This phase creates nothing new — it simply confirms the phrasing
+from `research.md` is the single source of truth for all later tasks.
+
+- [X] T001 Confirm the canonical wording from `specs/001-mark-fhir-unused/research.md` section "Wording standard (for FR-008 consistency)" is the phrase every later task must use verbatim: "not currently used — retained for backward compatibility; no runtime component reads this value." (short form: "reserved — not currently used"). No file edits in this task; this is the shared reference that all `[US1]`, `[US2]`, and `[US3]` tasks cite.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Verify, before any edits land, that the "no runtime consumer"
+assumption this entire feature rests on is still true. If this phase
+finds runtime code that reads `FHIR_SERVER`, STOP and revise the plan —
+the research assumption has been invalidated.
+
+**⚠️ CRITICAL**: No user story work may begin until this phase completes
+without surprises.
+
+- [X] T002 Re-run a case-insensitive repository search for `fhir` scoped to `flask_backend/` and `frontend/` (e.g., `grep -rni fhir flask_backend/ frontend/`) and confirm zero matches. **Result**: 0 matches in both directories. Assumption holds.
+- [X] T003 Re-run a case-insensitive repository search for `env.json` (e.g., `grep -rn env.json .`) and confirm the only match is `docker-entrypoint.sh`. **Result**: only matches outside the `specs/` directory are `docker-entrypoint.sh`. Assumption holds.
+
+**Checkpoint**: Assumptions verified. User story phases may begin in
+parallel.
+
+---
+
+## Phase 3: User Story 1 - New Contributor Reading Configuration (Priority: P1) 🎯 MVP
+
+**Goal**: Make it unambiguous to a new contributor — reading only
+environment templates and the README — that `FHIR_SERVER` is not
+currently used and is not required to run the stack.
+
+**Independent Test**: A reviewer opens `.env.example`, `default.env`,
+`.env.backup`, and the README's environment-variables section in a fresh
+clone of this branch and can correctly classify `FHIR_SERVER` as "not
+currently used" without reading any source code. Additionally, a local
+`docker-compose up` with no `FHIR_SERVER` line in `.env` starts cleanly
+and serves the primary workflow.
+
+### Implementation for User Story 1
+
+- [X] T004 [P] [US1] Edit `.env.example` (lines 9–10): comment out the `FHIR_SERVER=http://example-fhir-server.com` line and replace the existing `# URL to FHIR server used by the application` comment with the canonical phrase from T001. Do not delete the entry — it must remain visible as a commented reference so readers searching for "FHIR" land on the explanation.
+- [X] T005 [P] [US1] Edit `default.env` (lines 25–26): comment out `FHIR_SERVER=http://example-fhir-server.com` and replace the preceding `# URL to FHIR server used by the application` comment with the canonical phrase from T001. Preserve the surrounding section ordering.
+- [X] T006 [P] [US1] Edit `.env.backup` in two places — the already-commented historical block at lines 13–14 and the currently-active block at lines 51–52. In both places, annotate with the canonical phrase from T001 (the active-block entry must also be commented out so grep-based searches return the explanation). Do not delete either block; `.env.backup` is a historical snapshot and edits must preserve its structure.
+- [X] T007 [P] [US1] Edit `README.md` line 50: replace the `FHIR_SERVER` bullet with a single bullet whose description begins "**not currently used**" and then continues with "retained for backward compatibility with deployments that still set it; no runtime component reads this value." Keep the bullet in the existing environment-variables list so readers searching for "FHIR" in the README find the explanation.
+- [ ] T008 [US1] **Deferred to human operator** — requires Docker Compose. Local verification: from the repo root, run `cp .env.example .env` (after T004 lands), confirm `grep -i fhir .env` prints nothing, then run `docker-compose build && docker-compose up -d`. Wait for services to become healthy, open the frontend in a browser, log in, and walk the primary validation flow (list events → open an event → view a review). Confirm `docker-compose logs backend` contains zero mentions of FHIR and zero config-related errors or warnings. This task implements the Story 1 independent test and also satisfies SC-003 from `spec.md`.
+
+**Checkpoint**: Story 1 done. The MVP slice is complete — a new contributor
+can now correctly classify `FHIR_SERVER` as not currently used from
+config/README alone, and the stack runs without it. Safe to stop here and
+ship if time-boxed.
+
+---
+
+## Phase 4: User Story 2 - Architecture Doc Reader (Priority: P2)
+
+**Goal**: Remove the phantom-dependency misread from
+`docs/technical-architecture.md` so architects, auditors, and reviewers
+no longer conclude the system talks to a live FHIR server.
+
+**Independent Test**: A reader opens `docs/technical-architecture.md`,
+views the "Detailed System Architecture" Mermaid diagram, and correctly
+answers "no, this system does not currently talk to a FHIR server — the
+node is reserved and not wired up." Verifiable by rendering the diagram
+in any Mermaid preview and confirming no arrows connect `MCI_BE`, `VTE_BE`,
+or `CVA_BE` to the FHIR node, and that the node label includes "reserved
+— not currently used."
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Edit `docs/technical-architecture.md`: in the "Detailed System Architecture" Mermaid graph (lines 5–79), change the FHIR node declaration on line 39 from `FHIR[FHIR Server]` to `FHIR[FHIR Server<br/>reserved — not currently used]` and delete the three edges `MCI_BE --> FHIR`, `VTE_BE --> FHIR`, `CVA_BE --> FHIR` on lines 68–70. Leave the node in the `subgraph "External Systems"` block so revival context is preserved. Do not touch any other diagrams in the file; only Section 1 mentions FHIR.
+- [X] T010 [US2] In `docs/technical-architecture.md`, immediately below the closing ``` ``` ``` of the Section 1 Mermaid block, insert a one-paragraph note stating: the FHIR node is retained as a reserved placeholder, no runtime component in any study backend currently calls a FHIR server, and any future FHIR integration will be tracked as its own feature. Use the canonical wording from T001 as the key phrase.
+- [ ] T011 [US2] **Deferred to human operator** — requires a Mermaid-capable Markdown renderer. Render verification: open `docs/technical-architecture.md` in a Markdown viewer that supports Mermaid (VS Code preview or GitHub file view) and visually confirm that (a) the diagram still displays the FHIR node under "External Systems," (b) no arrows connect any study backend to the FHIR node, and (c) the new paragraph below the diagram is readable and uses the canonical phrase. Paste a screenshot or a copy of the rendered output into the PR description.
+
+**Checkpoint**: Story 2 done. Stories 1 and 2 are both independently
+verified; architecture docs no longer mislead stakeholders.
+
+---
+
+## Phase 5: User Story 3 - CI/Deployment Operator (Priority: P3)
+
+**Goal**: Remove the stale `FHIR_SERVER` entries from CI and the container
+entrypoint so operators maintaining those files do not treat the
+variable as a working dependency.
+
+**Independent Test**: An operator inspects `.github/workflows/tests.yml`
+and `docker-entrypoint.sh` and finds zero references to `FHIR_SERVER` in
+either file. A CI run on this branch passes `pytest flask_backend/tests/`
+without the variable being injected, and the container entrypoint
+starts cleanly on local Docker Compose.
+
+### Implementation for User Story 3
+
+- [X] T012 [P] [US3] Edit `.github/workflows/tests.yml`: delete line 25 (`FHIR_SERVER: http://test-server.com`) from the `env:` block under the `Run tests` step. Do not leave a YAML comment in its place; the whole point is that the env block now accurately reflects what the tests need. Confirm the remaining `LOG_LEVEL`, `LOG_FORMAT`, and `FRONTEND_ORIGIN` entries are untouched and the YAML indentation is preserved. **Verified**: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"` passes.
+- [X] T013 [P] [US3] Edit `docker-entrypoint.sh`: delete lines 4–7 (the `# Write environment variables used by the app` comment and the `if [ -n "$FHIR_SERVER" ]; then ... fi` block that writes `/var/www/html/env.json`). The resulting file must still `set -e` at the top and end with `exec "$@"`. Verify with `sh -n docker-entrypoint.sh` that the script still parses. **Verified**: `sh -n docker-entrypoint.sh` passes.
+- [ ] T014 [US3] **Deferred to human operator** — requires pushing the branch to the remote. CI verification: push the branch to the remote and confirm the `Python Tests` workflow run on this branch passes without the `FHIR_SERVER` env entry. If any test fails with a traceback mentioning FHIR, the Phase 2 research assumption was wrong — revert T012/T013 and revisit `research.md` before proceeding.
+- [ ] T015 [US3] **Deferred to human operator** — requires Docker. Entrypoint verification: rebuild the affected container (`docker-compose build`) and restart it (`docker-compose up -d`). Confirm the container starts cleanly, then `docker-compose exec` into it and verify `/var/www/html/env.json` is absent (because nothing writes it anymore) and that the application's primary workflow still functions. This satisfies SC-005 (zero runtime behavior change) for the entrypoint edit specifically.
+
+**Checkpoint**: All three stories are independently verified. The feature
+is ready for review.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency sweep and PR hygiene. These tasks touch
+no new files; they verify the whole feature hangs together and prepare
+the PR for review.
+
+- [X] T016 Run the full consistency sweep from `specs/001-mark-fhir-unused/quickstart.md` section 1: `grep -rni 'fhir' --include='*.md' --include='*.env*' --include='*.yml' --include='*.sh' .` from the repo root. Every hit must fall into one of two categories: (a) an annotated reference using the canonical phrase from T001, or (b) an intentional absence (zero hits in `docker-entrypoint.sh` and `.github/workflows/tests.yml`). **Result**: all remaining hits in `.env.example`, `default.env`, `.env.backup`, `README.md`, and `docs/technical-architecture.md` carry the canonical "not currently used" phrasing; `docker-entrypoint.sh` and `.github/workflows/tests.yml` have zero FHIR hits.
+- [ ] T017 **Deferred to human operator** — requires Docker. Run the explicit-`FHIR_SERVER` backward-compatibility check from `quickstart.md` section 3: add `FHIR_SERVER=http://legacy-value.example.com` to a local `.env`, restart the stack, and confirm the application behaves identically and backend logs contain zero FHIR mentions. This directly verifies Constitution Principle III (backwards compatibility) and the contract matrix in `specs/001-mark-fhir-unused/contracts/fhir-env-var.md`.
+- [ ] T018 **Deferred to human operator** — to be completed when the PR is opened. Update the PR description to state explicitly: (a) which studies the change affects ("all shared config — applies to every study deployment"), (b) that the change introduces zero runtime behavior changes, (c) that downstream deployments setting `FHIR_SERVER` in their real `.env` files remain unaffected, and (d) a link to `specs/001-mark-fhir-unused/spec.md` and `plan.md` for reviewers. This satisfies the "PRs MUST state which studies it affects" rule from the constitution's Development Workflow section.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. T001 is a one-off confirmation.
+- **Foundational (Phase 2)**: Depends on Setup. T002 and T003 MUST pass
+  (zero unexpected matches) before any user story work begins. If
+  either fails, the whole feature halts.
+- **User Story 1 (Phase 3)**: Depends on Phase 2. Independent of US2 and
+  US3 — can be merged alone as the MVP.
+- **User Story 2 (Phase 4)**: Depends on Phase 2. Independent of US1 and
+  US3. Touches only `docs/technical-architecture.md`.
+- **User Story 3 (Phase 5)**: Depends on Phase 2. Independent of US1 and
+  US2. Touches `.github/workflows/tests.yml` and `docker-entrypoint.sh`.
+- **Polish (Phase 6)**: Depends on whichever user stories are being
+  shipped in this PR. T016–T018 should be the last things done before
+  opening the PR.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent. No cross-story dependencies.
+- **US2 (P2)**: Independent. No cross-story dependencies.
+- **US3 (P3)**: Independent. No cross-story dependencies.
+
+All three stories can be implemented in parallel by different engineers
+once Phase 2 completes. They touch disjoint files.
+
+### Within Each User Story
+
+- US1: T004, T005, T006, T007 all edit different files and are fully
+  parallel. T008 is the verification task and must run after all four
+  edits land in the working tree.
+- US2: T009 and T010 both edit `docs/technical-architecture.md` and are
+  therefore sequential (same file). T011 is verification and runs after
+  T010.
+- US3: T012 and T013 edit different files and are parallel. T014
+  (CI verification) depends on T012 being pushed. T015 (entrypoint
+  verification) depends on T013.
+
+### Parallel Opportunities
+
+- Phase 2: T002 and T003 can run in parallel (both read-only searches).
+- Phase 3 (US1): T004, T005, T006, T007 run in parallel (four different
+  files).
+- Phase 5 (US3): T012 and T013 run in parallel (two different files).
+- Across phases: Once Phase 2 completes, all three user story phases
+  can run concurrently.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# After Phase 2 completes, launch all four Story 1 edits together:
+Task: "Edit .env.example lines 9–10 to comment out FHIR_SERVER and annotate"
+Task: "Edit default.env lines 25–26 to comment out FHIR_SERVER and annotate"
+Task: "Edit .env.backup lines 13–14 and 51–52 to annotate both FHIR blocks"
+Task: "Edit README.md line 50 to rewrite the FHIR_SERVER bullet"
+
+# Then sequentially run the verification:
+Task: "Run docker-compose smoke test with .env lacking FHIR_SERVER"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (T001) — confirm canonical wording.
+2. Complete Phase 2 (T002, T003) — verify research assumptions.
+3. Complete Phase 3 (T004–T008) — the four config/README edits plus
+   local smoke test.
+4. **STOP and VALIDATE**: Story 1 is independently shippable. This
+   alone resolves the highest-friction onboarding trap.
+5. Run T016–T018 and open a PR scoped to US1 only.
+
+### Incremental Delivery
+
+1. Setup + Foundational → research assumptions confirmed.
+2. Add US1 → open PR → merge (MVP).
+3. Add US2 → open follow-up PR → merge.
+4. Add US3 → open follow-up PR → merge.
+
+Each PR is independently reviewable and ships a complete, testable
+increment.
+
+### Single-Shot Delivery (Recommended for this feature)
+
+Because the total task count is small (18 tasks) and the file set is
+disjoint, a single PR covering all three stories is also reasonable.
+Do this if an engineer is picking up the whole feature at once:
+
+1. Phase 1 → Phase 2 → all three user story phases in parallel → Phase 6.
+2. Open one PR that lists the three stories in its description.
+
+The constitution's "one bundled PR for a small, coherent refactor" is
+consistent with this approach.
+
+---
+
+## Notes
+
+- Every edit task names its exact file and line range so an implementer
+  can apply the change without re-reading `research.md`.
+- The canonical phrase from T001 ("not currently used — retained for
+  backward compatibility; no runtime component reads this value.") is
+  the authoritative wording. Deviations MUST be justified in the PR.
+- This feature has no automated test tasks because the spec does not
+  request tests and there is zero runtime behavior to test. The existing
+  `pytest flask_backend/tests/` suite acts as the regression net.
+- If Phase 2 finds that `FHIR_SERVER` *is* actually consumed somewhere,
+  stop the feature immediately and revisit both `research.md` and
+  `plan.md` — the entire design rests on the "no runtime consumer"
+  claim.


### PR DESCRIPTION
Did these in Claude:
```
/speckit.specify This code references a FHIR server in several places, however there is no current need for it... Make edits to indicate that it's not currently used.
/speckit.plan
/speckit.tasks
/speckit.implement
```