### PR TITLE
Clean up the frontend build.

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-COPY package.json package-lock.json* ./
-RUN npm install --production=false \
-    && chmod +x node_modules/.bin/vite
+COPY package.json package-lock.json ./
+RUN npm ci --include=dev
 
 COPY . .
 


### PR DESCRIPTION
  - npm install --production=false → npm ci --include=dev — deterministic install from the lockfile, lighter on memory, no deprecated flag.
  - Dropped the chmod +x node_modules/.bin/vite workaround — npm ci sets .bin permissions correctly.
  - Dropped the * glob on package-lock.json — the file exists and npm ci requires it, so the build should fail loudly (not silently fall back) if it ever goes missing.