### PR TITLE
Interactive reviewer-assignment page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # cnics-validation Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-20
+Auto-generated from all feature plans. Last updated: 2026-05-21
 
 ## Active Technologies
 - N/A — documentation, Markdown, and inline comments + None added. `python-keycloak` is retained (already (002-constitution-sync)
 - N/A — no schema changes, no data changes. (002-constitution-sync)
 - Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend) + Flask, SQLAlchemy, mysql-connector-python; React 19, react-router-dom 6, Vite (003-scans-study)
 - MariaDB 10.11 — shared schema `init/02-schema.sql`; **no schema change in this feature** (003-scans-study)
+- Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend) + Flask, SQLAlchemy (backend); React 19, react-router-dom 6, Vite (frontend) (004-reviewer-assignment)
+- MariaDB 10.11, shared schema (`init/`). **No schema change in this feature.** (004-reviewer-assignment)
 
 - N/A — no code in a programming language is being + N/A. The repository's runtime stack (Flask + (001-mark-fhir-unused)
 
@@ -27,10 +29,10 @@ tests/
 N/A — no code in a programming language is being: Follow standard conventions
 
 ## Recent Changes
+- 004-reviewer-assignment: Added Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend) + Flask, SQLAlchemy (backend); React 19, react-router-dom 6, Vite (frontend)
 - 003-scans-study: Added Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend) + Flask, SQLAlchemy, mysql-connector-python; React 19, react-router-dom 6, Vite
 - 002-constitution-sync: Added N/A — documentation, Markdown, and inline comments + None added. `python-keycloak` is retained (already
 
-- 001-mark-fhir-unused: Added N/A — no code in a programming language is being + N/A. The repository's runtime stack (Flask +
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -1306,22 +1306,94 @@ def events_upload_raw(event_id: int):
 @requires_auth
 @requires_roles('admin')
 def events_assign_many():
+    """Assign a reviewer to a batch of events.
+
+    First-reviewer assignment advances each event to the shared `assigned`
+    state. A two-reviewer deployment supplies an optional `reviewer2_id`
+    alongside `slot: "first"` so both reviewers are assigned in one atomic
+    transaction (research Decision 4) — the To-Be-Assigned queue is gated on
+    `assign_date IS NULL`, so a per-slot call would drop the event before the
+    second reviewer could be assigned. Slot count is driven by the resolved
+    `reviewer_count` control, never by a study name (FR-008).
+    ---
+    parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+          required:
+            - event_ids
+            - reviewer_id
+            - slot
+          properties:
+            event_ids:
+              type: array
+              items:
+                type: integer
+              description: Non-empty list of event ids to assign
+            reviewer_id:
+              type: integer
+              description: The reviewer for `slot` (the first reviewer in Form B)
+            slot:
+              type: string
+              enum: [first, second, third]
+              description: Which reviewer slot to fill
+            reviewer2_id:
+              type: integer
+              description: >
+                Optional second reviewer. Valid only with `slot: "first"` in
+                a two-reviewer deployment; assigns both reviewers atomically.
+                Must differ from `reviewer_id`.
+    responses:
+      200:
+        description: Events assigned
+        schema:
+          type: object
+          properties:
+            data:
+              type: object
+              properties:
+                updated:
+                  type: integer
+      400:
+        description: Invalid assignment request
+      401:
+        description: Not authenticated
+      403:
+        description: Caller is not an administrator
+    """
     data = request.get_json() or {}
     event_ids = data.get('event_ids') or []
     reviewer_id = data.get('reviewer_id')
     slot = (data.get('slot') or '').strip()
+    reviewer2_id = data.get('reviewer2_id')
     if not isinstance(event_ids, list) or not reviewer_id or not slot:
         return jsonify({'error': 'event_ids, reviewer_id, and slot are required'}), 400
+    cfg = get_workflow_config()
     # In a single-reviewer configuration there is no second or third reviewer,
     # so those assignment slots are unavailable (FR-013).
-    if get_workflow_config().reviewer_count == 1 and slot in ('second', 'third'):
+    if cfg.reviewer_count == 1 and slot in ('second', 'third'):
         return jsonify({
             'error': 'Second- and third-reviewer assignment is unavailable when reviewer count is 1'
         }), 400
+    # Optional second reviewer — the atomic two-reviewer path (FR-010, FR-011).
+    if reviewer2_id is not None:
+        if cfg.reviewer_count == 1:
+            return jsonify({
+                'error': 'A second reviewer cannot be assigned when reviewer count is 1'
+            }), 400
+        if slot != 'first':
+            return jsonify({'error': 'reviewer2_id is only valid with the first slot'}), 400
+        if int(reviewer2_id) == int(reviewer_id):
+            return jsonify({'error': 'The first and second reviewer must be different people'}), 400
     auth_user = getattr(g, 'auth_user', None) or {}
     assigner_id = auth_user.get('id') or 0
     try:
-        result = table_service.assign_events(event_ids, int(reviewer_id), slot, int(assigner_id))
+        result = table_service.assign_events(
+            event_ids, int(reviewer_id), slot, int(assigner_id),
+            reviewer2_id=int(reviewer2_id) if reviewer2_id is not None else None,
+        )
         return jsonify({'data': result})
     except table_service.ValidationError as ve:
         return jsonify({'error': str(ve)}), 400

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -769,11 +769,18 @@ def get_events_awaiting_review(user_id: int, q: Optional[str] = None, site: Opti
         session.close()
 
 
-def assign_events(event_ids: list[int], reviewer_id: int, slot: str, assigner_id: int) -> dict:
+def assign_events(event_ids: list[int], reviewer_id: int, slot: str, assigner_id: int, reviewer2_id: Optional[int] = None) -> dict:
     """Assign a reviewer to many events for the given slot (first|second|third).
 
     Updates reviewerN_id and corresponding assign date/assigner fields where applicable.
     Returns { updated: N }.
+
+    When ``slot == "first"`` and ``reviewer2_id`` is supplied, the second
+    reviewer is assigned together with the first in the same transaction
+    (research Decision 4) — the queue predicate is ``assign_date IS NULL``,
+    so a per-slot call would drop the event from the queue before the second
+    reviewer could be assigned. ``reviewer2_id`` is ignored for the
+    ``second``/``third`` slots; existing positional callers are unaffected.
     """
     if slot not in {"first", "second", "third"}:
         raise ValidationError("slot must be one of: first, second, third")
@@ -791,6 +798,10 @@ def assign_events(event_ids: list[int], reviewer_id: int, slot: str, assigner_id
         for e in events:
             if slot == "first":
                 e.reviewer1_id = reviewer_id
+                # Two-reviewer deployments assign both reviewers atomically:
+                # set the second reviewer in the same loop / same commit.
+                if reviewer2_id is not None:
+                    e.reviewer2_id = reviewer2_id
                 # keep an audit of who assigned
                 e.assigner_id = assigner_id
                 e.assign_date = now

--- a/flask_backend/tests/test_assign_many.py
+++ b/flask_backend/tests/test_assign_many.py
@@ -1,0 +1,95 @@
+"""Atomic two-reviewer assignment (004-reviewer-assignment, research D4).
+
+`POST /api/events/assign_many` gains an optional `reviewer2_id` field so a
+two-reviewer deployment assigns both reviewers in one transaction — the
+queue predicate is `assign_date IS NULL`, so a per-slot call would drop the
+event from the queue before the second reviewer could be assigned.
+
+These tests use mocked sessions and the auto-admin `admin_client` fixture
+(see conftest.py); no database is required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import flask_backend.table_service as ts
+
+
+# --- Service layer: both reviewers set atomically (T009) --------------------
+
+
+@patch("flask_backend.table_service.get_session")
+def test_assign_events_two_reviewer_atomic(mock_get_session):
+    """slot='first' with reviewer2_id sets both reviewers, audit, and status
+    on every event within a single commit."""
+    events = [
+        SimpleNamespace(id=1, reviewer1_id=None, reviewer2_id=None,
+                        assigner_id=None, assign_date=None, status="uploaded"),
+        SimpleNamespace(id=2, reviewer1_id=None, reviewer2_id=None,
+                        assigner_id=None, assign_date=None, status="uploaded"),
+    ]
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = events
+    mock_get_session.return_value = session
+
+    result = ts.assign_events([1, 2], reviewer_id=7, slot="first",
+                              assigner_id=3, reviewer2_id=9)
+
+    assert result == {"updated": 2}
+    for e in events:
+        assert e.reviewer1_id == 7
+        assert e.reviewer2_id == 9
+        assert e.assigner_id == 3
+        assert e.assign_date is not None
+        assert e.status == "assigned"
+    # Atomic: one commit covers every event — all get both reviewers or none do.
+    session.commit.assert_called_once()
+
+
+# --- Endpoint validation: reviewer2_id is rejected when invalid (T010) ------
+
+
+def test_assign_many_rejects_reviewer2_when_count_one(admin_client, monkeypatch):
+    """A second reviewer cannot be assigned in a single-reviewer deployment."""
+    monkeypatch.setenv("REVIEWER_COUNT", "1")
+    res = admin_client.post("/api/events/assign_many", json={
+        "event_ids": [1], "reviewer_id": 7, "slot": "first", "reviewer2_id": 9,
+    })
+    assert res.status_code == 400
+    assert res.get_json().get("error")
+
+
+def test_assign_many_rejects_reviewer2_with_non_first_slot(admin_client, monkeypatch):
+    """reviewer2_id is only valid alongside the first slot."""
+    monkeypatch.setenv("REVIEWER_COUNT", "2")
+    res = admin_client.post("/api/events/assign_many", json={
+        "event_ids": [1], "reviewer_id": 7, "slot": "second", "reviewer2_id": 9,
+    })
+    assert res.status_code == 400
+    assert res.get_json().get("error")
+
+
+def test_assign_many_rejects_reviewer2_equals_reviewer(admin_client, monkeypatch):
+    """The same person must not fill both reviewer slots (FR-011)."""
+    monkeypatch.setenv("REVIEWER_COUNT", "2")
+    res = admin_client.post("/api/events/assign_many", json={
+        "event_ids": [1], "reviewer_id": 7, "slot": "first", "reviewer2_id": 7,
+    })
+    assert res.status_code == 400
+    assert res.get_json().get("error")
+
+
+# --- Endpoint happy path: reviewer2_id is forwarded to the service (T010) ---
+
+
+@patch("flask_backend.app.table_service.assign_events")
+def test_assign_many_forwards_reviewer2_id(mock_assign, admin_client, monkeypatch):
+    """A valid Form B body reaches assign_events with reviewer2_id."""
+    monkeypatch.setenv("REVIEWER_COUNT", "2")
+    mock_assign.return_value = {"updated": 1}
+    res = admin_client.post("/api/events/assign_many", json={
+        "event_ids": [1], "reviewer_id": 7, "slot": "first", "reviewer2_id": 9,
+    })
+    assert res.status_code == 200
+    assert res.get_json() == {"data": {"updated": 1}}
+    assert mock_assign.call_args.kwargs.get("reviewer2_id") == 9

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -11,7 +11,14 @@ function MenuBar({ admin, uploader, reviewer, third_reviewer }) {
       {admin && (
         <Link to={isVtePage ? "/vte/admin" : "/admin"}>Admin Tools</Link>
       )}
-      
+
+      {/* Assign Charts - reviewer-assignment page, only for admin users (FR-003).
+          Always the shared, config-driven page; the /vte/* fork is stale tech
+          debt and is not linked here (plan.md; Constitution Principle IV). */}
+      {admin && (
+        <Link to="/events/assignMany">Assign Charts</Link>
+      )}
+
       {/* Upload New Packets - for uploaders and admins */}
       {(uploader || admin) && (
         <Link to={isVtePage ? "/vte/upload" : "/events/upload"}>Upload New Packets</Link>

--- a/frontend/src/pages/EventAssignMany.jsx
+++ b/frontend/src/pages/EventAssignMany.jsx
@@ -1,22 +1,300 @@
+import { useEffect, useState } from 'react'
+import { showToast } from '../components/Toast'
+
+// Match App.jsx: '' in production (same-origin), VITE_API_URL in dev.
+const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')
+const PAGE_SIZE = 20
+
+// Interactive reviewer-assignment page. The administrator picks awaiting
+// events from the flag-aware "To Be Assigned" queue, chooses a reviewer
+// (or, in a two-reviewer deployment, a first and a second reviewer), and
+// confirms. A first-reviewer assignment advances each event to `assigned`
+// and removes it from the queue.
+//
+// The number of reviewer slots is driven entirely by the resolved
+// `workflow.reviewer_count` control, never by a study-name check
+// (Constitution Principle IV; FR-008/009/010).
 function EventAssignMany({ workflow }) {
-  // Reviewer-slot availability is driven by the resolved workflow control,
-  // never by a hard-coded study name (FR-019, FR-021). In a single-reviewer
-  // configuration only the first reviewer slot is offered.
-  const singleReviewer = (workflow && workflow.reviewer_count) === 1
+  const reviewerCount = Number(workflow && workflow.reviewer_count)
+  const twoReviewers = reviewerCount >= 2
+
+  const [rows, setRows] = useState([])
+  const [total, setTotal] = useState(0)
+  const [loadError, setLoadError] = useState(false)
+  const [reviewers, setReviewers] = useState([])
+  const [reviewersLoaded, setReviewersLoaded] = useState(false)
+  const [selected, setSelected] = useState({})
+  const [reviewerId, setReviewerId] = useState('')
+  const [reviewer2Id, setReviewer2Id] = useState('')
+  const [siteFilter, setSiteFilter] = useState('')
+  const [page, setPage] = useState(0)
+  const [status, setStatus] = useState('idle') // 'idle' | 'saving' | 'saved' | 'error'
+  const [message, setMessage] = useState('')
+
+  // Fetch the To-Be-Assigned queue. Explicit page/site arguments avoid
+  // stale-closure reads when called from event handlers.
+  const fetchQueue = (pageArg, siteArg) => {
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(pageArg * PAGE_SIZE),
+    })
+    if (siteArg) params.set('site', siteArg)
+    setLoadError(false)
+    fetch(`${API_BASE}/api/events/by_status/screened?${params.toString()}`, { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : Promise.reject(r)))
+      .then((j) => {
+        setRows(j.data || [])
+        setTotal(typeof j.total === 'number' ? j.total : (j.data || []).length)
+      })
+      .catch(() => {
+        setRows([])
+        setTotal(0)
+        setLoadError(true)
+      })
+  }
+
+  useEffect(() => {
+    fetchQueue(0, '')
+    // Reviewers are any users with the reviewer role (admins included) —
+    // the established pattern from EventAssignThird.jsx.
+    fetch(`${API_BASE}/api/tables/users?limit=2000`, { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : Promise.reject(r)))
+      .then((j) => {
+        setReviewers((j.data || []).filter((u) => u.reviewer_flag))
+        setReviewersLoaded(true)
+      })
+      .catch(() => {
+        setReviewers([])
+        setReviewersLoaded(true)
+      })
+  }, [])
+
+  const selectedIds = () =>
+    Object.keys(selected).filter((k) => selected[k]).map((k) => Number(k))
+
+  const toggle = (id) => setSelected((prev) => ({ ...prev, [id]: !prev[id] }))
+
+  const allSelected = rows.length > 0 && rows.every((r) => selected[r['ID']])
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelected({})
+    } else {
+      const next = {}
+      rows.forEach((r) => { next[r['ID']] = true })
+      setSelected(next)
+    }
+  }
+
+  // Site-filter options derive from the sites present in the loaded rows
+  // (the View All Events pattern). Changing the filter clears the current
+  // selection so a confirm never acts on now-hidden events.
+  const siteOptions = Array.from(new Set(rows.map((r) => r['Site']).filter(Boolean))).sort()
+  const handleSiteChange = (e) => {
+    const s = e.target.value
+    setSiteFilter(s)
+    setPage(0)
+    setSelected({})
+    fetchQueue(0, s)
+  }
+
+  // Pagination also clears the selection — a confirm acts only on events
+  // the administrator can currently see and chose (FR-016, spec Assumptions).
+  const goToPage = (p) => {
+    setPage(p)
+    setSelected({})
+    fetchQueue(p, siteFilter)
+  }
+  const hasPrev = page > 0
+  const hasNext = (page + 1) * PAGE_SIZE < total
+
+  const selCount = selectedIds().length
+  const samePerson = twoReviewers && !!reviewerId && reviewerId === reviewer2Id
+
+  // FR-018: spell out what is missing before a confirm is possible.
+  const missing = []
+  if (selCount === 0) missing.push('select at least one event')
+  if (!reviewerId) missing.push(twoReviewers ? 'choose a first reviewer' : 'choose a reviewer')
+  if (twoReviewers && !reviewer2Id) missing.push('choose a second reviewer')
+
+  const canSubmit =
+    selCount > 0 &&
+    !!reviewerId &&
+    (!twoReviewers || (!!reviewer2Id && !samePerson)) &&
+    status !== 'saving'
+
+  const handleAssign = async () => {
+    const ids = selectedIds()
+    if (!ids.length || !reviewerId) return
+    if (twoReviewers && (!reviewer2Id || samePerson)) return
+
+    setStatus('saving')
+    setMessage('')
+    const body = { event_ids: ids, reviewer_id: Number(reviewerId), slot: 'first' }
+    // Two-reviewer deployments assign both reviewers in one atomic request
+    // (research Decision 4) — the queue predicate is `assign_date IS NULL`,
+    // so a per-slot call would drop the event before the second reviewer.
+    if (twoReviewers) body.reviewer2_id = Number(reviewer2Id)
+
+    try {
+      const res = await fetch(`${API_BASE}/api/events/assign_many`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      })
+      let payload = null
+      try { payload = await res.json() } catch { /* no/invalid JSON body */ }
+
+      if (res.ok) {
+        const n = (payload && payload.data && payload.data.updated) || ids.length
+        setStatus('saved')
+        showToast(`Assigned ${n} event${n === 1 ? '' : 's'} to the chosen reviewer${twoReviewers ? 's' : ''}.`, 'success')
+        setSelected({})
+        setReviewerId('')
+        setReviewer2Id('')
+        // Re-fetch so assigned events leave the queue without a reload (FR-014).
+        fetchQueue(page, siteFilter)
+      } else {
+        setStatus('error')
+        const fallback =
+          res.status === 401 ? 'Your session has expired — please sign in again.'
+          : res.status === 403 ? 'You are not authorized to assign reviewers.'
+          : 'The assignment could not be completed. Please retry.'
+        const msg = (payload && payload.error) || fallback
+        setMessage(msg)
+        showToast(msg, res.status === 401 ? 'warning' : 'error')
+      }
+    } catch {
+      setStatus('error')
+      const msg = 'Network or server error while assigning — nothing was changed. Please retry.'
+      setMessage(msg)
+      showToast(msg, 'error')
+    }
+  }
 
   return (
     <div>
       <h1>Assign Charts</h1>
-      <p>This page will allow assigning many events to a reviewer.</p>
-      {singleReviewer ? (
-        <p>
-          This deployment is configured for a single reviewer — events are
-          assigned to one (first) reviewer. Second- and third-reviewer
-          assignment is unavailable.
-        </p>
-      ) : (
-        <p>Events may be assigned to first, second, or third reviewers.</p>
-      )}
+
+      <h2>Step 1: Select Event(s)</h2>
+      <div className="indent1">
+        {loadError ? (
+          <p>The assignment queue could not be loaded. Please reload the page.</p>
+        ) : rows.length === 0 ? (
+          <p>No events are awaiting reviewer assignment.</p>
+        ) : (
+          <>
+            <div style={{ display: 'flex', gap: '8px', margin: '8px 0', alignItems: 'center' }}>
+              {siteOptions.length > 0 && (
+                <select value={siteFilter} onChange={handleSiteChange}>
+                  <option value="">All Sites</option>
+                  {siteOptions.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              )}
+              <span style={{ fontSize: '.9em', color: '#444' }}>
+                {`Showing ${rows.length} of ${total}`}
+              </span>
+            </div>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleAll}
+                      aria-label="Select all events on this page"
+                    />
+                  </th>
+                  <th>Event Number</th>
+                  <th>Event Date</th>
+                  <th>Site</th>
+                  <th>Criteria</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r['ID']}>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={!!selected[r['ID']]}
+                        onChange={() => toggle(r['ID'])}
+                      />
+                    </td>
+                    <td>{r['ID']}</td>
+                    <td>{r['Date']}</td>
+                    <td>{r['Site']}</td>
+                    <td>{r['Criteria']}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div style={{ display: 'flex', gap: '8px', marginTop: '8px', alignItems: 'center' }}>
+              <button onClick={() => goToPage(page - 1)} disabled={!hasPrev}>Previous</button>
+              <span style={{ fontSize: '.9em' }}>Page {page + 1}</span>
+              <button onClick={() => goToPage(page + 1)} disabled={!hasNext}>Next</button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <h2 style={{ marginTop: '16px' }}>
+        Step 2: Choose Reviewer{twoReviewers ? 's' : ''}
+      </h2>
+      <div className="indent1">
+        {reviewersLoaded && reviewers.length === 0 ? (
+          <p>No users currently hold the reviewer role, so no reviewer can be assigned.</p>
+        ) : (
+          <>
+            <div>
+              <label>
+                {twoReviewers ? 'First reviewer: ' : 'Reviewer: '}
+                <select value={reviewerId} onChange={(e) => setReviewerId(e.target.value)}>
+                  <option value="">Select reviewer</option>
+                  {reviewers.map((u) => (
+                    <option key={u.id} value={u.id}>{u.username} ({u.site})</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {/* Second slot only when reviewer_count >= 2 — never a third
+                slot here (FR-010, FR-020). */}
+            {twoReviewers && (
+              <div style={{ marginTop: '8px' }}>
+                <label>
+                  Second reviewer:{' '}
+                  <select value={reviewer2Id} onChange={(e) => setReviewer2Id(e.target.value)}>
+                    <option value="">Select reviewer</option>
+                    {reviewers.map((u) => (
+                      <option key={u.id} value={u.id}>{u.username} ({u.site})</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            )}
+            {samePerson && (
+              <p style={{ color: '#c62828' }}>
+                The first and second reviewer must be different people.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <div style={{ marginTop: '12px' }}>
+        <button onClick={handleAssign} disabled={!canSubmit}>Assign</button>
+        {missing.length > 0 && (
+          <span style={{ marginLeft: '10px', fontSize: '.9em', color: '#444' }}>
+            To assign, {missing.join(', ')}.
+          </span>
+        )}
+      </div>
+
+      {status === 'saving' && <p>Assigning…</p>}
+      {status === 'error' && message && <p style={{ color: '#c62828' }}>{message}</p>}
     </div>
   )
 }

--- a/openapi.json
+++ b/openapi.json
@@ -107,7 +107,58 @@ paths:
   /api/events/bulk: {}
   /api/events/{int:event_id}/upload_scrubbed: {}
   /api/events/{int:event_id}/upload_raw: {}
-  /api/events/assign_many: {}
+  /api/events/assign_many:
+    post:
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+          required:
+          - event_ids
+          - reviewer_id
+          - slot
+          properties:
+            event_ids:
+              type: array
+              items:
+                type: integer
+              description: Non-empty list of event ids to assign
+            reviewer_id:
+              type: integer
+              description: The reviewer for `slot` (the first reviewer in Form B)
+            slot:
+              type: string
+              enum:
+              - first
+              - second
+              - third
+              description: Which reviewer slot to fill
+            reviewer2_id:
+              type: integer
+              description: 'Optional second reviewer. Valid only with `slot: "first"`
+                in a two-reviewer deployment; assigns both reviewers atomically. Must
+                differ from `reviewer_id`.
+
+                '
+      responses:
+        '200':
+          description: Events assigned
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  updated:
+                    type: integer
+        '400':
+          description: Invalid assignment request
+        '401':
+          description: Not authenticated
+        '403':
+          description: Caller is not an administrator
   /api/events/send_many: {}
   /api/events/{int:event_id}/review:
     post:

--- a/specs/004-reviewer-assignment/checklists/requirements.md
+++ b/specs/004-reviewer-assignment/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Interactive reviewer-assignment page
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- Integration-point references (the existing `POST /api/events/assign_many` endpoint, the reviewer-count workflow control, the stale `studies/vte/EventAssignMany.jsx` reference file) are deliberately confined to the **Recorded Prior Behavior** and **Dependencies** sections. They name existing system artifacts this feature must integrate with — they are not prescriptions for how to build the new page. The Functional Requirements and Success Criteria themselves remain implementation-agnostic.
+- No `[NEEDS CLARIFICATION]` markers were raised. The feature description was detailed enough to resolve every open question with a documented assumption (see the spec's **Assumptions** section), most notably: two-reviewer deployments capture both reviewers in one confirm action (FR-012), because assigning the first reviewer advances the event out of the queue.

--- a/specs/004-reviewer-assignment/contracts/assign_many.md
+++ b/specs/004-reviewer-assignment/contracts/assign_many.md
@@ -1,0 +1,123 @@
+# Contract: `POST /api/events/assign_many`
+
+**Feature**: 004-reviewer-assignment
+**Status**: Existing endpoint — **additive, backward-compatible extension**
+
+This endpoint assigns a reviewer to a batch of events. It is the only backend
+contract this feature touches. The single-slot forms below are **unchanged**;
+the only addition is the optional `reviewer2_id` field (research Decision 4).
+
+After this change lands, regenerate the API contract:
+`python -m flask_backend.generate_openapi` (run from the repository root) and
+commit the updated `openapi.json` in the same change (Constitution quality
+gate).
+
+---
+
+## Authorization
+
+- `@requires_auth` + `@requires_roles('admin')`.
+- Unauthenticated → `401`. Authenticated non-admin → `403`.
+
+---
+
+## Request
+
+`Content-Type: application/json`
+
+### Form A — single slot (existing, unchanged)
+
+Used by this page's **single-reviewer** path (`slot:"first"`) and by the
+third-reviewer page (`slot:"third"`).
+
+```json
+{
+  "event_ids": [12, 13, 14],
+  "reviewer_id": 7,
+  "slot": "first"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `event_ids` | array of int | yes | Must be a non-empty list |
+| `reviewer_id` | int | yes | The reviewer for `slot` |
+| `slot` | string | yes | `"first"` \| `"second"` \| `"third"` |
+
+### Form B — first + second reviewer, atomic (new)
+
+Used by this page's **two-reviewer** path (`reviewer_count == 2`).
+
+```json
+{
+  "event_ids": [12, 13, 14],
+  "reviewer_id": 7,
+  "slot": "first",
+  "reviewer2_id": 9
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `event_ids` | array of int | yes | Non-empty list |
+| `reviewer_id` | int | yes | The **first** reviewer |
+| `slot` | string | yes | Must be `"first"` |
+| `reviewer2_id` | int | yes (Form B) | The **second** reviewer; absent in Form A |
+
+---
+
+## Behavior
+
+| Case | Effect |
+|------|--------|
+| `slot == "first"`, no `reviewer2_id` | Sets `reviewer1_id`, `assigner_id`, `assign_date`; advances `status` → `assigned`. |
+| `slot == "first"`, with `reviewer2_id` | Sets `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`; advances `status` → `assigned`. **All events updated in one transaction (atomic).** |
+| `slot == "second"` | Sets `reviewer2_id`, `assigner_id`, `assign_date`. (Not used by this page.) |
+| `slot == "third"` | Sets `reviewer3_id`, `assigner3rd_id`, `assign3rd_date`; sends third-reviewer emails. (Not used by this page.) |
+
+`assigner_id` is the authenticated admin (audit trail).
+
+---
+
+## Responses
+
+### `200 OK`
+
+```json
+{ "data": { "updated": 3 } }
+```
+
+`updated` is the count of events written.
+
+### `400 Bad Request`
+
+`{ "error": "<message>" }` — surfaced verbatim to the admin (FR-017). Triggers:
+
+| Condition | Message (representative) |
+|-----------|--------------------------|
+| `event_ids`, `reviewer_id`, or `slot` missing | `event_ids, reviewer_id, and slot are required` |
+| `slot` not in {first, second, third} | `slot must be one of: first, second, third` |
+| `slot` ∈ {second, third} **and** `reviewer_count == 1` | `Second- and third-reviewer assignment is unavailable when reviewer count is 1` |
+| `reviewer2_id` present **and** `reviewer_count == 1` | `A second reviewer cannot be assigned when reviewer count is 1` |
+| `reviewer2_id` present **and** `slot != "first"` | `reviewer2_id is only valid with the first slot` |
+| `reviewer2_id == reviewer_id` | `The first and second reviewer must be different people` |
+
+### `401 Unauthorized` / `403 Forbidden`
+
+Not authenticated / not an admin. The page surfaces an authorization message
+and claims no success (FR-004, FR-017).
+
+### `500 Internal Server Error`
+
+`{ "error": "Failed to assign events" }` — surfaced as a generic failure;
+the admin can retry (FR-017).
+
+---
+
+## Backward compatibility
+
+- Form A bodies behave exactly as before this feature.
+- `pages/EventAssignThird.jsx` (`slot:"third"`) is unaffected.
+- `table_service.assign_events(event_ids, reviewer_id, slot, assigner_id)`
+  gains a trailing optional `reviewer2_id=None`; existing positional callers
+  (including backend tests) are unaffected.

--- a/specs/004-reviewer-assignment/data-model.md
+++ b/specs/004-reviewer-assignment/data-model.md
@@ -1,0 +1,107 @@
+# Phase 1 Data Model: Interactive reviewer-assignment page
+
+**Feature**: 004-reviewer-assignment
+**Date**: 2026-05-21
+
+**No schema change.** This feature introduces no new tables and no new
+columns. It reads existing data and writes existing `events` columns through
+the existing `assign_events` service function. This document records the
+shapes the page reads and writes so the design is unambiguous.
+
+---
+
+## Entities (all pre-existing)
+
+### Awaiting event (read — the queue)
+
+Source: `GET /api/events/by_status/screened` →
+`table_service.get_to_be_assigned_with_total`. Each row:
+
+| Field | Meaning |
+|-------|---------|
+| `ID` | Event id (used as `event_ids` element on assign) |
+| `Date` | Event date |
+| `Created` | `events.add_date` |
+| `Uploaded` | `events.upload_date` |
+| `Scrubbed` | `events.scrub_date` (empty when scrubbing bypassed) |
+| `Criteria` | Comma-joined criteria names |
+| `Site` | Patient site (drives the site filter) |
+
+Membership rule (flag-aware, `_ready_to_assign_predicate()`): an event is in
+this queue when `upload_date IS NOT NULL`, **and** `scrub_date IS NOT NULL`
+if scrubbing is enabled, **and** `screen_date IS NOT NULL` if screening is
+enabled, **and** `assign_date IS NULL`. The trailing `assign_date IS NULL`
+term is why assignment must be atomic (see research Decision 4).
+
+Envelope: `{ "data": [ ...rows ], "total": <int> }`. Supports `limit`,
+`offset`, `site` query params.
+
+### Eligible reviewer (read — the selector)
+
+Source: `GET /api/tables/users?limit=2000`, client-filtered to
+`reviewer_flag` truthy. Fields used: `id`, `username`, `site`,
+`reviewer_flag`. A reviewer may also be an admin.
+
+### Workflow configuration (read — slot count)
+
+Source: the `workflow` prop on `EventAssignMany` (from `GET /api/config`).
+Field used: `reviewer_count` (integer, `1` or `2`). `1` → one reviewer slot;
+`2` → first + second slots. Never branch on `study_type`.
+
+### Reviewer assignment (write — `events` columns)
+
+Written by `table_service.assign_events`. No new columns.
+
+| `events` column | Set when |
+|-----------------|----------|
+| `reviewer1_id` | `slot == "first"` — the first reviewer |
+| `reviewer2_id` | `slot == "second"`, **or** `slot == "first"` with `reviewer2_id` supplied (new atomic path) |
+| `assigner_id` | every assignment — the acting admin (audit) |
+| `assign_date` | every assignment — today's date |
+| `status` | set to `assigned` **only** on a first-reviewer assignment |
+
+`reviewer3_id` / `assigner3rd_id` / `assign3rd_date` are **not** written by
+this page (third-reviewer assignment is out of scope, FR-020).
+
+---
+
+## State transition
+
+Only one event-lifecycle transition is caused by this feature:
+
+```
+screened ─┐
+          ├──(first-reviewer assignment)──▶ assigned
+uploaded ─┘   (uploaded→assigned occurs when scrubbing/screening bypassed)
+```
+
+- A **first-reviewer** assignment sets `status = "assigned"` (FR-013). The
+  event leaves the To-Be-Assigned queue because both `assign_date` is now set
+  and the status advanced.
+- A **second-reviewer-only** assignment (`slot == "second"`, used by the
+  existing endpoint contract but **not** by this page) sets `reviewer2_id`
+  and `assign_date` without advancing `status`.
+- This page's two-reviewer path always assigns the first reviewer (plus the
+  second, atomically), so it always produces the `→ assigned` transition.
+
+Bypassed states (`scrubbed`, `screened`, `sent`, `reviewer2_done`,
+`third_review_*`) remain defined in the schema and shared state machine
+(Constitution Principle V); this feature neither removes nor renames any.
+
+---
+
+## Validation rules (enforced at write time)
+
+| Rule | Where enforced | Spec ref |
+|------|----------------|----------|
+| `event_ids` non-empty list, `reviewer_id` present, `slot` present | endpoint → `400` | FR-018 |
+| `slot` ∈ {`first`, `second`, `third`} | `assign_events` → `ValidationError`/`400` | — |
+| `second`/`third` slot rejected when `reviewer_count == 1` | endpoint → `400` (existing) | FR-009 |
+| `reviewer2_id` rejected when `reviewer_count == 1` | endpoint → `400` (new) | FR-009 |
+| `reviewer2_id` accepted only with `slot == "first"` | endpoint → `400` (new) | research D4 |
+| `reviewer2_id != reviewer_id` (no person in two slots) | endpoint → `400` (new) + client block | FR-011 |
+| Action restricted to admin | `@requires_roles('admin')` (existing) → `401`/`403` | FR-004 |
+
+Client-side, the page also blocks submission with no events selected, no
+reviewer chosen, or the same person in both slots (FR-011, FR-018) before any
+request is sent.

--- a/specs/004-reviewer-assignment/plan.md
+++ b/specs/004-reviewer-assignment/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Interactive reviewer-assignment page
+
+**Branch**: `004-reviewer-assignment` | **Date**: 2026-05-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-reviewer-assignment/spec.md`
+
+## Summary
+
+Replace the static `frontend/src/pages/EventAssignMany.jsx` placeholder with a working reviewer-assignment page. An administrator opens the "To Be Assigned" queue (the flag-aware queue already shown on View All Events), selects one or more events, chooses a reviewer (or, in a two-reviewer deployment, a first and a second reviewer), and confirms. On success the events advance — first-reviewer assignment moves an event to the `assigned` status — and leave the queue.
+
+The page is **one shared page for all studies**; the number of reviewer slots is driven entirely by the resolved `reviewer_count` workflow control (already passed to the component as the `workflow` prop), never by a study-name check (Constitution Principle IV).
+
+Technical approach: the single-reviewer path (P1, the MVP that unblocks the scans lifecycle) is **frontend-only** — it uses the existing `POST /api/events/assign_many` endpoint unchanged. The two-reviewer path (P2) requires a small, backward-compatible backend extension so that both reviewers are assigned in **one atomic transaction**; research below establishes that one-call-per-slot cannot satisfy FR-012 ("fully assigned before it advances out of the queue") because the queue is gated on `assign_date IS NULL` and any single-slot call sets `assign_date`.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend)
+**Primary Dependencies**: Flask, SQLAlchemy (backend); React 19, react-router-dom 6, Vite (frontend)
+**Storage**: MariaDB 10.11, shared schema (`init/`). **No schema change in this feature.**
+**Testing**: `pytest` (backend, `flask_backend/tests/`). The frontend has no test runner configured — verification is `eslint` + manual checks against a running deployment.
+**Target Platform**: Linux server, Docker Compose stack (`web` + `backend` + `mariadb`)
+**Project Type**: Web application (React frontend + Flask backend)
+**Performance Goals**: Interactive admin tooling — a batch assignment completes within ~2 s; queue pages are 20 events.
+**Constraints**: Admin-only action; single canonical `.env` / `docker-compose.yaml`; no cross-study data access; the queue and slot count must be flag-driven, not study-name-driven.
+**Scale/Scope**: One frontend page rewritten, one menu link added, one backend endpoint + one service function extended (additive), one backend test added, `openapi.json` regenerated. Queues of up to a few hundred events, paginated.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Assessment | Status |
+|-----------|------------|--------|
+| **I. Single Codebase, Many Studies** | The page is a single shared `pages/EventAssignMany.jsx` serving every study. No fork, no new study branch. The pre-existing `studies/vte/EventAssignMany.jsx` is a separate, stale per-study copy — **not touched** by this feature and explicitly out of scope (see Complexity / note below). | ✅ Pass |
+| **II. Study Data Isolation** | No cross-study access. The page operates only on the current deployment's events and users. | ✅ Pass |
+| **III. Backwards Compatibility With Legacy Data** | No schema change. No change to legacy CNICS/CakePHP data contracts or to `cnics_data.Patients` views. The `assign_many` request-body extension touches *this app's own* pre-release API only — governed by Principle VI, not III. | ✅ Pass |
+| **IV. Configuration Over Code Forks** | Reviewer-slot count is read from the resolved `reviewer_count` workflow control (`workflow` prop / `GET /api/config`). No `STUDY_TYPE` branch, no study-name `if/elif`. The queue uses the existing flag-aware `by_status/screened` endpoint. | ✅ Pass |
+| **V. Workflow and Role Parity Across Studies** | Uses shared lifecycle state names (`assigned`) and shared roles (`reviewer`, `admin`) unchanged. Honors `REVIEWER_COUNT` selective bypass: a single-reviewer deployment shows one slot and the backend already rejects second/third slots. No shared state redefined, removed, or renamed. | ✅ Pass |
+| **VI. Pre-Release Iteration and Discovery** | Recorded prior behavior (the static placeholder) is captured in the spec. The `assign_many` body extension is a permitted pre-release change to this app's own API; `openapi.json` MUST be regenerated in the same change (quality gate). Research records that the spec's "partial failure across slots" edge case is superseded by the atomic design, with the rationale. | ✅ Pass |
+| **Security & Data Governance** | `POST /api/events/assign_many` already carries `@requires_auth` + `@requires_roles('admin')`; the extension adds no new endpoint and no new role surface. The `/events/assignMany` route is already admin-gated in `App.jsx`. The reviewer list is read from the existing `GET /api/tables/users` (`@requires_auth`); it exposes only low-sensitivity usernames/sites, no PHI. No patient identifiers logged. | ✅ Pass |
+| **Quality Gates** | `openapi.json` regenerated after the request-body change; a backend integration test added for the two-reviewer atomic path exercising the admin role decorator. PR states scope = shared (all studies). | ✅ Pass |
+
+**Result**: No violations. Complexity Tracking table is empty.
+
+*Note (not a violation): `frontend/src/studies/vte/EventAssignMany.jsx` is a stale per-study duplicate of this page that posts an obsolete request shape. It is reached only via the separate `/vte/assignMany` route and is **out of scope** here. Converging or retiring it is pre-existing tech debt for a future change; this plan neither depends on it nor modifies it.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-reviewer-assignment/
+├── plan.md              # This file (/speckit.plan command output)
+├── spec.md              # Feature specification (/speckit.specify)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+│   └── assign_many.md   # Updated contract for POST /api/events/assign_many
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (/speckit.specify)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+└── src/
+    ├── pages/
+    │   └── EventAssignMany.jsx     # REWRITE: placeholder → working assignment page
+    ├── components/
+    │   ├── MenuBar.jsx             # EDIT: add admin "Assign Charts" menu link (FR-003)
+    │   ├── DataTable.jsx           # reused for the pageable queue display (read-only)
+    │   └── Toast.js                # reused for success/error feedback (read-only)
+    └── App.jsx                     # no change — /events/assignMany route already exists, admin-gated
+
+flask_backend/
+├── app.py                         # EDIT: events_assign_many() accepts optional reviewer2_id
+├── table_service.py               # EDIT: assign_events() — atomic two-reviewer path
+└── tests/
+    └── test_*.py                  # ADD: two-reviewer atomic assignment test + slot validation
+
+openapi.json                       # REGENERATE: python -m flask_backend.generate_openapi
+```
+
+**Structure Decision**: Existing web-application layout (`frontend/` React + `flask_backend/` Flask). This feature is concentrated in one rewritten frontend page plus a small additive backend extension. The frontend route and the backend endpoint already exist; no new files are created in source code — only the placeholder page is rewritten and four existing files are edited.
+
+## Phase 0: Research
+
+See [research.md](./research.md). Key decisions:
+
+1. **Queue source** — reuse `GET /api/events/by_status/screened`, which dispatches to the flag-aware `get_to_be_assigned_with_total`. With scrubbing/screening bypassed it surfaces `uploaded` events; identical to View All Events' "To Be Assigned" section.
+2. **Reviewer list** — reuse `GET /api/tables/users?limit=2000`, filtering `reviewer_flag` client-side (the pattern already used by `pages/EventAssignThird.jsx`). No new endpoint.
+3. **Single-reviewer assignment (P1)** — one `POST /api/events/assign_many` call with `{event_ids, reviewer_id, slot:"first"}`. **No backend change.**
+4. **Two-reviewer assignment (P2)** — requires an **atomic** backend extension. One-call-per-slot is rejected: the queue predicate is `assign_date IS NULL`, and every single-slot call sets `assign_date`, so the event would leave the queue after the first call, violating FR-012. The endpoint gains an optional `reviewer2_id` field (valid only with `slot:"first"`); `assign_events` sets both reviewers + status in one transaction.
+5. **Reference implementation** — `pages/EventAssignThird.jsx` is the structural model (it already uses the *current* endpoint contract). `studies/vte/EventAssignMany.jsx` is used for layout ideas only — its request shape is stale.
+6. **Spec edge case superseded** — with the atomic design, "partial failure across slots" cannot occur; the whole assignment succeeds or fails together. Recorded per Principle VI.
+
+## Phase 1: Design & Contracts
+
+- **Data model**: [data-model.md](./data-model.md) — no new entities or schema; documents the existing `events` columns the assignment writes (`reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, `status`) and the queue/reviewer read shapes.
+- **Contracts**: [contracts/assign_many.md](./contracts/assign_many.md) — the updated `POST /api/events/assign_many` contract (existing single-slot form + new optional `reviewer2_id`).
+- **Quickstart**: [quickstart.md](./quickstart.md) — how to exercise both the single-reviewer and two-reviewer paths.
+- **Agent context**: refreshed via `.specify/scripts/bash/update-agent-context.sh claude`.
+
+## Complexity Tracking
+
+> No Constitution Check violations. No entries required.

--- a/specs/004-reviewer-assignment/quickstart.md
+++ b/specs/004-reviewer-assignment/quickstart.md
@@ -1,0 +1,94 @@
+# Quickstart: Interactive reviewer-assignment page
+
+**Feature**: 004-reviewer-assignment
+**Date**: 2026-05-21
+
+How to exercise the feature once implemented. The canonical environment is the
+Docker Compose stack (`docker compose up`); there is no separate local stack.
+
+---
+
+## Reaching the page
+
+- **From View All Events**: open *View All Events* → expand the **To Be
+  Assigned** section → click **assign** on any row. (The button already
+  routes to `/events/assignMany`.)
+- **From the menu**: an admin-only **Assign Charts** link in the top menu
+  (added by this feature, FR-003).
+- The `/events/assignMany` route is admin-gated; a non-admin is blocked by
+  `ProtectedRoute` before the page renders.
+
+---
+
+## Path 1 — Single-reviewer deployment (P1, e.g. scans)
+
+Deployment has `REVIEWER_COUNT=1` (scrubbing/screening/sending bypassed).
+
+1. Open the assignment page. The **To Be Assigned** queue lists events
+   awaiting assignment — for scans these are events in the `uploaded` status
+   (flag-aware queue).
+2. Confirm exactly **one** reviewer selector is shown — no second/third slot
+   (FR-009).
+3. Select one or more events with their checkboxes.
+4. Choose a reviewer (any user with the reviewer role, admins included).
+5. Click **Assign**. Expect a success toast; the assigned events disappear
+   from the queue without a manual reload (FR-014).
+6. Verify in *View All Events*: the events moved out of **To Be Assigned**;
+   their status is `assigned`.
+
+**Lifecycle check (SC-005)**: an event can now go
+`uploaded → assigned → reviewer1_done → done` — the stage that was previously
+impossible is unblocked.
+
+---
+
+## Path 2 — Two-reviewer deployment (P2)
+
+Deployment has `REVIEWER_COUNT=2`.
+
+1. Open the assignment page. Confirm **two** reviewer selectors — first and
+   second (FR-010). No third slot (FR-020).
+2. Select one or more events.
+3. Choose a first reviewer and a **different** second reviewer.
+4. Try selecting the **same** person in both slots → confirmation is blocked
+   with an explanatory message (FR-011).
+5. With two distinct reviewers, click **Assign**. One atomic request is sent;
+   on success both reviewers are recorded on every selected event and the
+   events leave the queue (FR-014).
+6. Verify in *View All Events*: events show `assigned` status with both
+   reviewers populated.
+
+---
+
+## Error handling checks (FR-017, SC-004)
+
+| Trigger | Expected |
+|---------|----------|
+| Confirm with no events selected, or no reviewer chosen | Submission blocked client-side; page indicates what is missing (FR-018) |
+| Session expired / not admin | `401`/`403` surfaced as an authorization message; no success claimed |
+| Server/network failure | Failure surfaced; admin can retry; no false success |
+| Empty queue | Clear empty-state message, not an error |
+| No users hold the reviewer role | Page communicates that no reviewer can be chosen |
+
+---
+
+## Filtering & pagination (P3)
+
+- Apply the **site** filter → only that site's events remain (FR-015).
+- With more than 20 events, use **Previous/Next** to page through the queue
+  (FR-016).
+
+---
+
+## Regression / verification
+
+- **Backend**: `pytest flask_backend/tests/` — includes a new test for the
+  atomic two-reviewer assignment and the new `400` validations. Existing
+  `test_scans_workflow.py` / `test_full_workflow_defaults.py` still pass
+  (the `assign_events` signature change is additive).
+- **API contract**: `openapi.json` regenerated
+  (`python -m flask_backend.generate_openapi`) and committed.
+- **Frontend**: `npm run lint` in `frontend/` is clean (no test runner is
+  configured; verify behavior manually against the running stack).
+- **Third-reviewer page** (`/events/assignThird`) still assigns correctly —
+  it uses `slot:"third"`, unaffected by the extension.

--- a/specs/004-reviewer-assignment/research.md
+++ b/specs/004-reviewer-assignment/research.md
@@ -1,0 +1,213 @@
+# Phase 0 Research: Interactive reviewer-assignment page
+
+**Feature**: 004-reviewer-assignment
+**Date**: 2026-05-21
+
+This document resolves the open questions from the spec — chiefly the spec's
+explicit ask: *"confirm whether the endpoint needs any change to assign first
+and second reviewers in a single operation, or whether the page issues one
+call per slot."*
+
+---
+
+## Decision 1 — Queue source: reuse `GET /api/events/by_status/screened`
+
+**Decision**: The page loads the "To Be Assigned" queue from
+`GET /api/events/by_status/screened`, with `limit`, `offset`, and `site`
+query parameters.
+
+**Rationale**: `flask_backend/app.py` routes `by_status/screened` to
+`table_service.get_to_be_assigned_with_total`, which builds its WHERE clause
+from `_ready_to_assign_predicate()`. That predicate is **flag-aware**: it
+requires `upload_date IS NOT NULL`, adds `scrub_date IS NOT NULL` only when
+`ENABLE_SCRUBBING` is on, adds `screen_date IS NOT NULL` only when
+`ENABLE_SCREENING` is on, and always requires `assign_date IS NULL`. For a
+scans deployment (scrubbing and screening bypassed) this reduces to
+`upload_date IS NOT NULL AND assign_date IS NULL` — i.e. events still in the
+`uploaded` status appear in the queue, exactly as the spec requires (FR-002).
+This is the same endpoint the View All Events page uses for its "To Be
+Assigned" section, so the two views stay consistent.
+
+**Response shape**: `{ data: [ {ID, Date, Created, Uploaded, Scrubbed,
+Criteria, Site}, ... ], total: <int> }`. The endpoint supports `site`
+filtering and `limit`/`offset` pagination server-side (FR-015, FR-016).
+
+**Alternatives considered**:
+- *Generic `get_events_by_status_with_total("screened", …)`* — rejected: it
+  filters strictly on `e.status = 'screened'` and is **not** flag-aware, so a
+  scans deployment (events in `uploaded`) would show an empty queue.
+- *A new dedicated endpoint* — rejected: unnecessary; the flag-aware helper
+  already exists and is already in production use.
+
+---
+
+## Decision 2 — Reviewer list: reuse `GET /api/tables/users`
+
+**Decision**: Populate the reviewer selector(s) from
+`GET /api/tables/users?limit=2000`, filtering to rows with a truthy
+`reviewer_flag` on the client.
+
+**Rationale**: This is the established pattern — `pages/EventAssignThird.jsx`
+does exactly this. A "reviewer" is any user with the reviewer role flag set,
+which includes admins who also review (FR-006). `users` rows carry `id`,
+`username`, `site`, and `reviewer_flag`, which is everything the selector
+needs. The endpoint is `@requires_auth`; the page itself is admin-gated, and
+the data (usernames/sites) contains no PHI, so no stricter protection is
+warranted.
+
+**Alternatives considered**:
+- *New `GET /api/users/reviewers` endpoint* — rejected for this feature: adds
+  backend surface for no functional gain. Reusing the existing reader keeps
+  the single-reviewer MVP (P1) entirely frontend-side.
+
+---
+
+## Decision 3 — Single-reviewer assignment (P1): existing endpoint, no backend change
+
+**Decision**: For `reviewer_count == 1`, the page issues one request:
+`POST /api/events/assign_many` with body
+`{ event_ids: [...], reviewer_id: <id>, slot: "first" }`.
+
+**Rationale**: The endpoint already exists, is admin-only, and on a
+first-reviewer assignment sets `reviewer1_id`, `assigner_id`, `assign_date`
+and advances `status` to `assigned` (`table_service.assign_events`). This
+fully satisfies the P1 user story and unblocks the scans
+upload → assign → review → done lifecycle with **zero backend changes**.
+
+---
+
+## Decision 4 — Two-reviewer assignment (P2): atomic backend extension *(answers the spec's open question)*
+
+**Decision**: The two-reviewer case requires a **backend change**. The page
+issues **one** request that carries both reviewers; the backend assigns them
+in a **single transaction**. `POST /api/events/assign_many` gains an optional
+`reviewer2_id` field, accepted only with `slot: "first"`.
+
+**Why one-call-per-slot does NOT work** — this is the decisive finding:
+
+The "To Be Assigned" queue predicate (`_ready_to_assign_predicate()`) ends
+with `e.assign_date IS NULL`. In `assign_events`, **every** slot — `first`,
+`second`, and `third` — sets `assign_date = today`. Therefore the *first* of
+two sequential per-slot calls already sets `assign_date`, which immediately
+removes the event from the To-Be-Assigned queue regardless of which slot was
+written first. There is no call ordering that keeps a partially-assigned
+event in the queue between the two calls.
+
+That directly violates **FR-012** ("the administrator MUST choose a reviewer
+for both slots before confirming, so that an event is fully assigned before
+it advances out of the queue") and **FR-014** ("on a successful assignment …
+the assigned events MUST leave the queue"). Worse, a partial failure (call 1
+succeeds, call 2 fails) leaves an event with `assign_date` set, one reviewer
+missing, and `status` possibly still `screened` — it disappears from the
+To-Be-Assigned queue but surfaces in "To Be Sent" (whose predicate is
+`assign_date IS NOT NULL AND send_date IS NULL`) with a missing reviewer, and
+there is no UI to repair it. That is an unrecoverable bad state.
+
+**The change (additive, backward-compatible)**:
+
+- `POST /api/events/assign_many` accepts an **optional** `reviewer2_id`.
+  - Existing single-slot bodies (`{event_ids, reviewer_id, slot}` for
+    `first`/`second`/`third`) behave exactly as before.
+  - When `slot == "first"` **and** `reviewer2_id` is present, both reviewers
+    are assigned together.
+- `table_service.assign_events` gains a trailing optional parameter
+  `reviewer2_id=None`. When `slot == "first"` and `reviewer2_id` is provided,
+  it sets `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and
+  `status = "assigned"` for every event in **one `session.commit()`** — so
+  the assignment is atomic: all events get both reviewers, or none do.
+- Validation (returned as `400` so the page can surface it, FR-017):
+  - `reviewer2_id` is rejected when `reviewer_count == 1` (consistent with
+    the existing rejection of `second`/`third` slots).
+  - `reviewer2_id` is rejected unless `slot == "first"`.
+  - `reviewer2_id == reviewer_id` is rejected — server-side enforcement of
+    FR-011 ("the same person MUST NOT be assigned to more than one slot"),
+    in addition to the client-side block.
+
+**Backward compatibility**: `pages/EventAssignThird.jsx` posts
+`{event_ids, reviewer_id, slot:"third"}` — unaffected. Backend tests call
+`assign_events(event_ids, reviewer_id, slot, assigner_id)` positionally with
+no fifth argument — unaffected because `reviewer2_id` defaults to `None`. Per
+Constitution Principle VI this is a permitted pre-release change to the app's
+own API; `openapi.json` MUST be regenerated in the same change.
+
+**Alternatives considered**:
+- *Two sequential per-slot calls* — rejected: cannot satisfy FR-012/FR-014
+  and creates an unrecoverable partial state (analysis above).
+- *A brand-new `assign_pair` endpoint* — rejected: more surface than needed;
+  an optional field on the existing admin-only endpoint is smaller and keeps
+  one assignment endpoint.
+- *Resurrecting the stale `{reviewer1_id, reviewer2_id}` shape* — rejected:
+  that shape drops `slot` entirely and would collide conceptually with the
+  third-reviewer flow; keeping `slot` as the discriminator is clearer.
+
+---
+
+## Decision 5 — Spec edge case "partial failure across slots" is superseded
+
+**Decision**: The spec's edge case *"Partial failure across … slots … the
+page reports which events/slots were assigned and which were not"* no longer
+applies and is replaced by all-or-nothing behavior.
+
+**Rationale (recorded per Constitution Principle VI)**: That edge case was
+written anticipating a possible one-call-per-slot implementation. Decision 4
+makes the two-reviewer assignment atomic in a single transaction, so a
+partial slot outcome is impossible — the request either fully succeeds or
+fully fails with nothing written. The remaining, simpler edge case is: the
+whole assignment fails (validation, auth, server, or network error), nothing
+changes, the error is surfaced (FR-017), and the admin retries. This is a
+strictly better outcome than reporting an unrepairable half-assigned state.
+
+---
+
+## Decision 6 — Slot count is driven by `reviewer_count`, never by study name
+
+**Decision**: The page reads `workflow.reviewer_count` (already passed to
+`EventAssignMany` as a prop from `App.jsx`, sourced from `GET /api/config`).
+`reviewer_count === 1` → render one reviewer selector. `reviewer_count >= 2`
+→ render a first and a second reviewer selector. No `STUDY_TYPE` or
+study-name check anywhere (Constitution Principle IV; FR-008/009/010).
+
+**Rationale**: `App.jsx` already fetches `/api/config` and passes the
+resolved `workflow` object (with a conservative `reviewer_count: 2` default
+until config resolves). The component only needs to consume it. Third-reviewer
+slots are never rendered here (FR-020) — that is a separate page.
+
+---
+
+## Decision 7 — Page composition and feedback
+
+**Decision**:
+- Structure follows `pages/EventAssignThird.jsx`: a selectable event table
+  (checkbox column, "select all" affordance), reviewer selector(s), and a
+  confirm button. Add a site-filter `<select>` and Previous/Next pagination
+  driven by the endpoint's `total`.
+- Site-filter options are derived from the `Site` values present in the
+  loaded rows (the pattern used by View All Events); changing the filter
+  re-fetches with `site=`.
+- Success and error feedback use the existing `showToast` helper plus an
+  inline status line. On success the page re-fetches the queue so assigned
+  events disappear without a manual reload (FR-014).
+- The confirm button is disabled until at least one event is selected and
+  every visible reviewer slot has a selection (FR-018); in a two-reviewer
+  deployment, selecting the same person in both slots blocks confirmation
+  with an explanatory message (FR-011).
+
+**Rationale**: Reuses established components (`DataTable` for the read-only
+parts is optional; a hand-rolled selectable table matches the existing
+assign pages and supports the checkbox column cleanly) and the existing
+toast pattern, keeping the change small and consistent with sibling pages.
+
+---
+
+## Summary of backend impact
+
+| Path | P1 (single reviewer) | P2 (two reviewers) |
+|------|----------------------|--------------------|
+| `frontend/src/pages/EventAssignMany.jsx` | Rewritten | Rewritten (same file) |
+| `frontend/src/components/MenuBar.jsx` | Add admin link (FR-003) | — |
+| `flask_backend/app.py` | No change | Accept optional `reviewer2_id` |
+| `flask_backend/table_service.py` | No change | `assign_events` atomic two-reviewer path |
+| `flask_backend/tests/` | (optional) | Add atomic two-reviewer test |
+| `openapi.json` | No change | Regenerate |
+
+P1 ships frontend-only. The backend change is scoped entirely to P2.

--- a/specs/004-reviewer-assignment/spec.md
+++ b/specs/004-reviewer-assignment/spec.md
@@ -1,0 +1,131 @@
+# Feature Specification: Interactive reviewer-assignment page
+
+**Feature Branch**: `004-reviewer-assignment`
+**Created**: 2026-05-21
+**Status**: Draft
+**Input**: User description: "Build the interactive reviewer-assignment page for the event-validation workflow, replacing the current frontend/src/pages/EventAssignMany.jsx placeholder."
+
+## Recorded Prior Behavior *(Constitution Principle VI)*
+
+Today the reviewer-assignment page (`EventAssignMany.jsx`) is a static placeholder: it renders descriptive text only, never calls the backend, and cannot perform an assignment. The assignment endpoint exists but has no working user interface. As a result, events that reach the "To Be Assigned" stage cannot be moved forward, and the validation lifecycle stalls before the "assigned" status. This feature replaces that placeholder with a working page.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Assign a reviewer to awaiting events (single-reviewer deployment) (Priority: P1)
+
+An administrator opens the "To Be Assigned" queue, sees the events currently awaiting reviewer assignment, selects one or more of them, chooses a reviewer, and confirms. The selected events advance to the "assigned" status, the admin sees a confirmation, and the assigned events leave the queue.
+
+**Why this priority**: This is the minimum viable slice. It is the exact step that is missing today and that blocks the lifecycle for every study type. In particular, it unblocks a single-reviewer scans deployment so it can complete its upload → assign → review → done lifecycle. Without it, no event can ever progress past "To Be Assigned."
+
+**Independent Test**: In a deployment configured for one reviewer, open the To Be Assigned queue, select one or more events, pick a reviewer, confirm, and verify the events advance to "assigned" and disappear from the queue. Delivers the core value on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator is viewing the To Be Assigned queue with events awaiting assignment, **When** they select one event, choose a reviewer, and confirm, **Then** the event advances to the "assigned" status, a confirmation is shown, and the event no longer appears in the queue.
+2. **Given** an administrator has selected several events, **When** they choose one reviewer and confirm, **Then** that same reviewer is applied to every selected event and all of them leave the queue.
+3. **Given** the deployment is configured for a single reviewer, **When** the administrator views the assignment controls, **Then** exactly one (first) reviewer slot is offered and no second- or third-reviewer slot is shown.
+4. **Given** an administrator attempts to confirm with no events selected, or with no reviewer chosen, **When** they trigger the confirm action, **Then** the assignment is not submitted and the page indicates what is missing.
+5. **Given** the assignment endpoint returns a validation, authorization, or server error, **When** the administrator confirms an assignment, **Then** the page surfaces a human-readable error message and does not claim success.
+
+---
+
+### User Story 2 - Assign first and second reviewers (two-reviewer deployment) (Priority: P2)
+
+In a deployment configured for two reviewers, an administrator selects events from the queue, chooses a first reviewer and a second reviewer, and confirms. Both reviewers are recorded on every selected event and the events advance out of the queue.
+
+**Why this priority**: It extends the same page to the two-reviewer study configurations. It is essential for those deployments but is not required to unblock the single-reviewer scans lifecycle, so it ranks below P1. The page is one shared page for all studies; the number of reviewer slots is driven entirely by the resolved `reviewer_count` workflow control, never by a study-name check.
+
+**Independent Test**: In a deployment configured for two reviewers, open the queue, select events, choose two distinct reviewers, confirm, and verify both reviewer assignments are recorded and the events advance.
+
+**Acceptance Scenarios**:
+
+1. **Given** the deployment is configured for two reviewers, **When** the administrator views the assignment controls, **Then** a first-reviewer slot and a second-reviewer slot are both offered.
+2. **Given** a two-reviewer deployment, **When** the administrator chooses the same person for both the first and second reviewer slots, **Then** the page prevents confirming and indicates the two reviewers must be different.
+3. **Given** a two-reviewer deployment with a first and second reviewer selected, **When** the administrator confirms, **Then** both reviewer assignments are applied to every selected event and the events advance out of the queue.
+
+---
+
+### User Story 3 - Narrow and page through the queue (Priority: P3)
+
+An administrator working with a large queue narrows it by site and pages through the results, the same way the "To Be Assigned" list behaves on the View All Events page.
+
+**Why this priority**: For small queues the P1 flow works without filtering or paging. Filtering and pagination become necessary only as the queue grows, so this is a usability enhancement layered on top of the core flow.
+
+**Independent Test**: Open a queue large enough to span multiple pages, apply a site filter, page forward and back, and verify the displayed events match the filter and page.
+
+**Acceptance Scenarios**:
+
+1. **Given** the queue contains events from more than one site, **When** the administrator applies a site filter, **Then** only events for that site are shown.
+2. **Given** the queue contains more events than fit on one page, **When** the administrator moves to the next page, **Then** the next set of awaiting events is shown.
+
+---
+
+### Edge Cases
+
+- **Empty queue**: When no events are awaiting assignment, the page shows a clear empty-state message rather than an error or a blank table.
+- **No eligible reviewers**: When no users hold the reviewer role, the administrator cannot choose a reviewer; the page communicates this rather than failing silently.
+- **Re-assignment**: Assigning a reviewer to an event that already has one is permitted; the system does not block re-assignment to a different reviewer.
+- **Session or role lost**: When the administrator's session has expired or they lack the admin role, the assignment is rejected, the page surfaces the authorization error, and no success is claimed.
+- **Endpoint rejects the slot**: When a second- or third-reviewer assignment is attempted in a single-reviewer deployment, the endpoint rejects it; the page surfaces that error. (The page already hides those slots in a single-reviewer deployment, so this is a defense-in-depth case.)
+- **Partial failure across a batch or across slots**: When an assignment covering multiple events — or, in a two-reviewer deployment, multiple reviewer slots — partly succeeds, the page reports which events/slots were assigned and which were not, rather than reporting a blanket success.
+- **Server or network failure**: When the request cannot complete, the page surfaces the failure and the administrator can retry; the page does not falsely report success.
+- **Selection vs. filtering/paging**: When the administrator changes the site filter or page after selecting events, the confirmed assignment applies only to events the administrator selected and intends.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The reviewer-assignment page MUST replace the current placeholder with a working interface that performs assignments; descriptive-only text that cannot perform an action MUST NOT remain.
+- **FR-002**: The page MUST display the "To Be Assigned" queue — the same flag-aware queue shown on the View All Events page — listing events currently awaiting reviewer assignment. When scrubbing and screening are bypassed, this queue includes events in the "uploaded" status.
+- **FR-003**: The queue MUST be reachable from the "To Be Assigned" section of the View All Events page and from the application menu.
+- **FR-004**: Performing an assignment MUST be restricted to administrators; non-administrators MUST NOT be able to assign reviewers.
+- **FR-005**: The administrator MUST be able to select one or more events from the queue.
+- **FR-006**: The administrator MUST be able to choose a reviewer from the users who hold the reviewer role; this includes administrators who also hold the reviewer role.
+- **FR-007**: The reviewer the administrator chooses MUST be applied to every selected event in a single confirm action.
+- **FR-008**: The number of reviewer slots the page offers MUST be driven by the resolved `reviewer_count` workflow control, never by a study-name check (Constitution Principle IV, Configuration Over Code Forks).
+- **FR-009**: When `reviewer_count` is 1, the page MUST offer exactly one (first) reviewer slot and MUST NOT show a second- or third-reviewer slot.
+- **FR-010**: When `reviewer_count` is 2, the page MUST offer a first-reviewer slot and a second-reviewer slot.
+- **FR-011**: When two reviewer slots are offered, the same person MUST NOT be assignable to more than one reviewer slot on the same event; the page MUST prevent confirming such a combination.
+- **FR-012**: When two reviewer slots are offered, the administrator MUST choose a reviewer for both slots before confirming, so that an event is fully assigned before it advances out of the queue.
+- **FR-013**: Assigning the first reviewer MUST advance each affected event to the "assigned" status.
+- **FR-014**: On a successful assignment, the page MUST show a confirmation, and the assigned events MUST leave the queue without requiring a manual page reload.
+- **FR-015**: The queue MUST support filtering by site.
+- **FR-016**: The queue MUST support pagination.
+- **FR-017**: The page MUST surface the assignment endpoint's validation, authorization, and server errors to the administrator as human-readable messages.
+- **FR-018**: The page MUST prevent submitting an assignment when no events are selected or no reviewer is chosen, and MUST indicate what is missing.
+- **FR-019**: The system MUST permit re-assigning an event to a different reviewer; the page MUST NOT block an assignment solely because an event already has a reviewer.
+- **FR-020**: Third-reviewer (post-disagreement) assignment is out of scope for this page and MUST NOT be offered here; it is a separate stage with its own page.
+
+### Key Entities *(include if feature involves data)*
+
+- **Awaiting event**: An event in the "To Be Assigned" queue — an event that has not yet been assigned a reviewer. Identified to the administrator by event number, event date, patient identifier, and site. It carries a lifecycle status that, after a successful first-reviewer assignment, becomes "assigned."
+- **Eligible reviewer**: A user who holds the reviewer role. May also hold the administrator role. Distinguished to the administrator by name and site.
+- **Reviewer slot**: The position a reviewer fills on an event — first or second (third is out of scope for this page). The set of slots offered is determined by the resolved `reviewer_count` workflow control.
+- **Reviewer-count workflow control**: A resolved per-deployment configuration value that determines how many reviewer slots the page offers (1 for a single-reviewer deployment such as scans, 2 for a two-reviewer deployment).
+- **Assignment action**: The administrator's confirmed intent — a set of selected events plus the chosen reviewer(s) — applied together.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An administrator can take a batch of awaiting events and assign a reviewer in under 60 seconds, with no placeholder or descriptive-only text remaining on the page.
+- **SC-002**: After a successful assignment, 100% of the assigned events disappear from the "To Be Assigned" queue without the administrator manually reloading the page.
+- **SC-003**: In a single-reviewer deployment, the page presents exactly one reviewer slot and zero second- or third-reviewer slots.
+- **SC-004**: Every error the assignment endpoint returns — invalid input, not authorized, or server failure — results in a visible, human-readable message; there are no silent failures.
+- **SC-005**: A single-reviewer scans deployment can complete the full upload → assign → review → done lifecycle, where previously it stalled before the "assigned" status.
+- **SC-006**: In a two-reviewer deployment, an assignment cannot be confirmed with the same person selected for both reviewer slots, and cannot be confirmed with either slot left empty.
+
+## Assumptions
+
+- **Reviewer eligibility**: A reviewer is any user holding the reviewer role, including administrators who also review. No additional site-matching or workload constraint is applied to reviewer eligibility for this feature.
+- **Two-reviewer assignment is a single action**: Because assigning the first reviewer advances an event to "assigned" and removes it from the queue, a two-reviewer deployment must capture both reviewers in one confirm action; otherwise the second reviewer could never be assigned from this page (FR-012). The send page and review page are out of scope, so they cannot fill a missing second reviewer.
+- **Queue source**: The "To Be Assigned" queue uses the same flag-aware status query that the View All Events page already uses for its "To Be Assigned" section, so bypassed scrubbing/screening behavior is consistent between the two pages.
+- **Selection scope**: Event selection operates on the events the administrator can currently see; selecting events across many filtered/paginated views simultaneously is not required for this feature.
+- **Re-assignment scope**: "Permit re-assignment" means the page and the system impose no "already has a reviewer" restriction. A dedicated flow for locating an already-assigned event (one that has left the queue) and changing its reviewer is not part of this page; such an event is reached through other existing routes.
+- **No schema change**: This feature introduces no database schema change.
+
+## Dependencies
+
+- **Assignment endpoint**: The backend endpoint `POST /api/events/assign_many` already exists. It is admin-only and accepts a set of event ids, one reviewer id, and a slot of first/second/third. First-reviewer assignment advances status to "assigned," and the endpoint already rejects second/third slots when `reviewer_count` is 1. The endpoint currently records one reviewer and one slot per call. Planning must confirm whether assigning a first and a second reviewer in a two-reviewer deployment is done by issuing one call per slot, or whether the endpoint needs a change to accept both in a single operation — and, if one call per slot, how partial failure across slots is reported (see Edge Cases).
+- **Reviewer-count workflow control**: The resolved `reviewer_count` value is already exposed to the frontend through the existing workflow configuration; this feature consumes it and does not define new configuration.
+- **Reference UI only**: A study-specific assignment page exists at `frontend/src/studies/vte/EventAssignMany.jsx`. It is stale — it sends a request shape that does not match the current endpoint — and must be treated as a guide to page structure only, not to the request contract.

--- a/specs/004-reviewer-assignment/tasks.md
+++ b/specs/004-reviewer-assignment/tasks.md
@@ -23,7 +23,7 @@ Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths 
 
 **Purpose**: Pre-flight confirmation. No new dependencies and no new files — the `/events/assignMany` route already exists.
 
-- [ ] T001 Pre-flight check (read-only, no code change): confirm in `frontend/src/App.jsx` that the `/events/assignMany` route is wrapped in `ProtectedRoute requiredRoles={['admin']}` and renders `<EventAssignMany workflow={workflow} />`, and that `workflow.reviewer_count` is populated from `GET /api/config`. Record any deviation before proceeding.
+- [X] T001 Pre-flight check (read-only, no code change): confirm in `frontend/src/App.jsx` that the `/events/assignMany` route is wrapped in `ProtectedRoute requiredRoles={['admin']}` and renders `<EventAssignMany workflow={workflow} />`, and that `workflow.reviewer_count` is populated from `GET /api/config`. Record any deviation before proceeding.
 
 ---
 
@@ -33,9 +33,9 @@ Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths 
 
 **⚠️ CRITICAL**: T003 and T004 must complete before any user story phase — US1/US2/US3 all extend this page.
 
-- [ ] T002 [P] Add an admin-only "Assign Charts" link to `frontend/src/components/MenuBar.jsx` pointing to `/events/assignMany` (FR-003). Gate it on the `admin` prop, alongside the existing "Admin Tools" link. (The View All Events page already links to the page via its per-row "assign" button — no task needed there.)
-- [ ] T003 Replace the placeholder body of `frontend/src/pages/EventAssignMany.jsx` with a working component scaffold that keeps the `{ workflow }` prop: on mount, fetch the To-Be-Assigned queue from `GET /api/events/by_status/screened` (`credentials: 'include'`, with `limit`/`offset`) storing `rows` and `total`, and fetch reviewers from `GET /api/tables/users?limit=2000` filtered client-side to truthy `reviewer_flag`. Use `API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')`.
-- [ ] T004 In `frontend/src/pages/EventAssignMany.jsx`, render the queue as a selectable event table — a checkbox per row plus a select-all control — showing event id, event date, patient identifier, and site. Render a clear empty-state message when the queue is empty, and a notice when no users hold the reviewer role (spec Edge Cases).
+- [X] T002 [P] Add an admin-only "Assign Charts" link to `frontend/src/components/MenuBar.jsx` pointing to `/events/assignMany` (FR-003). Gate it on the `admin` prop, alongside the existing "Admin Tools" link. (The View All Events page already links to the page via its per-row "assign" button — no task needed there.)
+- [X] T003 Replace the placeholder body of `frontend/src/pages/EventAssignMany.jsx` with a working component scaffold that keeps the `{ workflow }` prop: on mount, fetch the To-Be-Assigned queue from `GET /api/events/by_status/screened` (`credentials: 'include'`, with `limit`/`offset`) storing `rows` and `total`, and fetch reviewers from `GET /api/tables/users?limit=2000` filtered client-side to truthy `reviewer_flag`. Use `API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')`.
+- [X] T004 In `frontend/src/pages/EventAssignMany.jsx`, render the queue as a selectable event table — a checkbox per row plus a select-all control — showing event id, event date, patient identifier, and site. Render a clear empty-state message when the queue is empty, and a notice when no users hold the reviewer role (spec Edge Cases).
 
 **Checkpoint**: The page loads, lists awaiting events with checkboxes, and lists reviewers — but cannot yet assign.
 
@@ -49,9 +49,9 @@ Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths 
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] In `frontend/src/pages/EventAssignMany.jsx`, render the first-reviewer `<select>` (always shown), populated from the fetched reviewers as `username (site)`. Drive slot rendering off `workflow.reviewer_count` so a single-reviewer deployment shows exactly one slot and no second/third slot (FR-008, FR-009).
-- [ ] T006 [US1] In `frontend/src/pages/EventAssignMany.jsx`, implement the confirm action for the single-reviewer path: `POST /api/events/assign_many` with body `{ event_ids, reviewer_id, slot: "first" }`. Disable the confirm button until at least one event is selected and a reviewer is chosen; indicate what is missing otherwise (FR-005, FR-007, FR-018).
-- [ ] T007 [US1] In `frontend/src/pages/EventAssignMany.jsx`, handle the assign response: on success show a confirmation via `showToast` (from `components/Toast`) and re-fetch the queue so assigned events leave it without a manual reload (FR-013, FR-014); on `400`/`401`/`403`/`500` surface the response's `error` message (or an auth/network message) as human-readable feedback and claim no success (FR-017, spec Edge Cases).
+- [X] T005 [US1] In `frontend/src/pages/EventAssignMany.jsx`, render the first-reviewer `<select>` (always shown), populated from the fetched reviewers as `username (site)`. Drive slot rendering off `workflow.reviewer_count` so a single-reviewer deployment shows exactly one slot and no second/third slot (FR-008, FR-009).
+- [X] T006 [US1] In `frontend/src/pages/EventAssignMany.jsx`, implement the confirm action for the single-reviewer path: `POST /api/events/assign_many` with body `{ event_ids, reviewer_id, slot: "first" }`. Disable the confirm button until at least one event is selected and a reviewer is chosen; indicate what is missing otherwise (FR-005, FR-007, FR-018).
+- [X] T007 [US1] In `frontend/src/pages/EventAssignMany.jsx`, handle the assign response: on success show a confirmation via `showToast` (from `components/Toast`) and re-fetch the queue so assigned events leave it without a manual reload (FR-013, FR-014); on `400`/`401`/`403`/`500` surface the response's `error` message (or an auth/network message) as human-readable feedback and claim no success (FR-017, spec Edge Cases).
 
 **Checkpoint**: User Story 1 is fully functional — a single-reviewer deployment can assign reviewers end to end. **This is the MVP.**
 
@@ -67,15 +67,15 @@ Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths 
 
 ### Tests for User Story 2
 
-- [ ] T008 [P] [US2] Add a backend test in `flask_backend/tests/test_table_service.py` (or a new `test_assign_many.py`) for the atomic two-reviewer path: assert `table_service.assign_events(event_ids, reviewer_id, "first", assigner_id, reviewer2_id=<id>)` sets `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and `status="assigned"` on every event; and assert `POST /api/events/assign_many` returns `400` when `reviewer2_id` is given with `reviewer_count==1`, with `slot != "first"`, and when `reviewer2_id == reviewer_id`. Write this before T009–T010 and confirm it fails first.
+- [X] T008 [P] [US2] Add a backend test in `flask_backend/tests/test_table_service.py` (or a new `test_assign_many.py`) for the atomic two-reviewer path: assert `table_service.assign_events(event_ids, reviewer_id, "first", assigner_id, reviewer2_id=<id>)` sets `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and `status="assigned"` on every event; and assert `POST /api/events/assign_many` returns `400` when `reviewer2_id` is given with `reviewer_count==1`, with `slot != "first"`, and when `reviewer2_id == reviewer_id`. Write this before T009–T010 and confirm it fails first.
 
 ### Implementation for User Story 2
 
-- [ ] T009 [US2] Extend `table_service.assign_events` in `flask_backend/table_service.py` with a trailing optional parameter `reviewer2_id=None`. When `slot == "first"` and `reviewer2_id` is provided, set `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and `status = "assigned"` for all matched events within the single existing `session.commit()` (atomic). Existing positional callers are unaffected.
-- [ ] T010 [US2] Extend `events_assign_many` in `flask_backend/app.py` to read optional `reviewer2_id` from the request body and pass it to `assign_events`. Return `400` with a human-readable `error` when: `reviewer2_id` is present and `get_workflow_config().reviewer_count == 1`; `reviewer2_id` is present and `slot != "first"`; or `reviewer2_id == reviewer_id` (server-side FR-011). Update the endpoint docstring's Swagger block to document `reviewer2_id`.
-- [ ] T011 [US2] Regenerate the API contract: run `python -m flask_backend.generate_openapi` from the repository root and commit the updated `openapi.json` (Constitution quality gate).
-- [ ] T012 [US2] In `frontend/src/pages/EventAssignMany.jsx`, render the second-reviewer `<select>` only when `workflow.reviewer_count >= 2` (never a third slot — FR-010, FR-020). Require both slots filled before confirm is enabled (FR-012), and block confirmation with an explanatory message when the same person is selected in both slots (FR-011).
-- [ ] T013 [US2] In `frontend/src/pages/EventAssignMany.jsx`, send the two-reviewer assignment as a single request `{ event_ids, reviewer_id, slot: "first", reviewer2_id }` and surface the new `400` validation messages from T010 (FR-017). Reuse the success/queue-refresh handling from T007.
+- [X] T009 [US2] Extend `table_service.assign_events` in `flask_backend/table_service.py` with a trailing optional parameter `reviewer2_id=None`. When `slot == "first"` and `reviewer2_id` is provided, set `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and `status = "assigned"` for all matched events within the single existing `session.commit()` (atomic). Existing positional callers are unaffected.
+- [X] T010 [US2] Extend `events_assign_many` in `flask_backend/app.py` to read optional `reviewer2_id` from the request body and pass it to `assign_events`. Return `400` with a human-readable `error` when: `reviewer2_id` is present and `get_workflow_config().reviewer_count == 1`; `reviewer2_id` is present and `slot != "first"`; or `reviewer2_id == reviewer_id` (server-side FR-011). Update the endpoint docstring's Swagger block to document `reviewer2_id`.
+- [X] T011 [US2] Regenerate the API contract: run `python -m flask_backend.generate_openapi` from the repository root and commit the updated `openapi.json` (Constitution quality gate).
+- [X] T012 [US2] In `frontend/src/pages/EventAssignMany.jsx`, render the second-reviewer `<select>` only when `workflow.reviewer_count >= 2` (never a third slot — FR-010, FR-020). Require both slots filled before confirm is enabled (FR-012), and block confirmation with an explanatory message when the same person is selected in both slots (FR-011).
+- [X] T013 [US2] In `frontend/src/pages/EventAssignMany.jsx`, send the two-reviewer assignment as a single request `{ event_ids, reviewer_id, slot: "first", reviewer2_id }` and surface the new `400` validation messages from T010 (FR-017). Reuse the success/queue-refresh handling from T007.
 
 **Checkpoint**: Both single-reviewer (US1) and two-reviewer (US2) deployments assign reviewers correctly and independently.
 
@@ -89,8 +89,8 @@ Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths 
 
 ### Implementation for User Story 3
 
-- [ ] T014 [US3] In `frontend/src/pages/EventAssignMany.jsx`, add a site-filter `<select>` whose options derive from the distinct `Site` values in the loaded queue rows (the View All Events pattern). On change, re-fetch the queue with the `site` query parameter and clear the current event selection so a confirm never acts on hidden events (FR-015, spec Edge Cases / Assumptions).
-- [ ] T015 [US3] In `frontend/src/pages/EventAssignMany.jsx`, add Previous/Next pagination (page size 20) driven by the endpoint's `total`, re-fetching with `limit`/`offset`; clear the event selection on page change (FR-016).
+- [X] T014 [US3] In `frontend/src/pages/EventAssignMany.jsx`, add a site-filter `<select>` whose options derive from the distinct `Site` values in the loaded queue rows (the View All Events pattern). On change, re-fetch the queue with the `site` query parameter and clear the current event selection so a confirm never acts on hidden events (FR-015, spec Edge Cases / Assumptions).
+- [X] T015 [US3] In `frontend/src/pages/EventAssignMany.jsx`, add Previous/Next pagination (page size 20) driven by the endpoint's `total`, re-fetching with `limit`/`offset`; clear the event selection on page change (FR-016).
 
 **Checkpoint**: All three user stories are independently functional.
 
@@ -100,9 +100,9 @@ Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths 
 
 **Purpose**: Verification and quality gates across the whole feature.
 
-- [ ] T016 [P] Run `npm run lint` in `frontend/` and resolve any issues introduced in `EventAssignMany.jsx` and `MenuBar.jsx`.
-- [ ] T017 [P] Run `pytest flask_backend/tests/` and confirm the new T008 test passes and the existing `test_scans_workflow.py` and `test_full_workflow_defaults.py` still pass (the `assign_events` signature change is additive).
-- [ ] T018 Validate the feature against `specs/004-reviewer-assignment/quickstart.md`: single-reviewer path, two-reviewer path, error cases (no selection, not admin, server error, empty queue, no reviewers), and site filter + pagination.
+- [X] T016 [P] Run `npm run lint` in `frontend/` and resolve any issues introduced in `EventAssignMany.jsx` and `MenuBar.jsx`.
+- [X] T017 [P] Run `pytest flask_backend/tests/` and confirm the new T008 test passes and the existing `test_scans_workflow.py` and `test_full_workflow_defaults.py` still pass (the `assign_events` signature change is additive).
+- [X] T018 Validate the feature against `specs/004-reviewer-assignment/quickstart.md`: single-reviewer path, two-reviewer path, error cases (no selection, not admin, server error, empty queue, no reviewers), and site filter + pagination.
 
 ---
 

--- a/specs/004-reviewer-assignment/tasks.md
+++ b/specs/004-reviewer-assignment/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Interactive reviewer-assignment page
+
+**Input**: Design documents from `/specs/004-reviewer-assignment/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/assign_many.md
+
+**Tests**: The frontend has no test runner configured, so there are no frontend test tasks. One **backend** test task is included for the two-reviewer atomic path — required by the plan and by the Constitution quality gate ("new backend endpoints SHOULD have at least one integration test").
+
+**Organization**: Tasks are grouped by user story. The feature is concentrated in one rewritten frontend file (`frontend/src/pages/EventAssignMany.jsx`) plus a small additive backend extension; parallelism is therefore limited and is marked honestly.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different file, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 — maps to the spec's user stories
+- All paths are repository-relative to `/home/debadmin/cnics-validation/`
+
+## Path Conventions
+
+Web application: `frontend/src/` (React 19) and `flask_backend/` (Flask). Paths below are exact.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Pre-flight confirmation. No new dependencies and no new files — the `/events/assignMany` route already exists.
+
+- [ ] T001 Pre-flight check (read-only, no code change): confirm in `frontend/src/App.jsx` that the `/events/assignMany` route is wrapped in `ProtectedRoute requiredRoles={['admin']}` and renders `<EventAssignMany workflow={workflow} />`, and that `workflow.reviewer_count` is populated from `GET /api/config`. Record any deviation before proceeding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the page substrate (queue + reviewers + selectable table) that every user story extends, and make the page reachable from the menu.
+
+**⚠️ CRITICAL**: T003 and T004 must complete before any user story phase — US1/US2/US3 all extend this page.
+
+- [ ] T002 [P] Add an admin-only "Assign Charts" link to `frontend/src/components/MenuBar.jsx` pointing to `/events/assignMany` (FR-003). Gate it on the `admin` prop, alongside the existing "Admin Tools" link. (The View All Events page already links to the page via its per-row "assign" button — no task needed there.)
+- [ ] T003 Replace the placeholder body of `frontend/src/pages/EventAssignMany.jsx` with a working component scaffold that keeps the `{ workflow }` prop: on mount, fetch the To-Be-Assigned queue from `GET /api/events/by_status/screened` (`credentials: 'include'`, with `limit`/`offset`) storing `rows` and `total`, and fetch reviewers from `GET /api/tables/users?limit=2000` filtered client-side to truthy `reviewer_flag`. Use `API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')`.
+- [ ] T004 In `frontend/src/pages/EventAssignMany.jsx`, render the queue as a selectable event table — a checkbox per row plus a select-all control — showing event id, event date, patient identifier, and site. Render a clear empty-state message when the queue is empty, and a notice when no users hold the reviewer role (spec Edge Cases).
+
+**Checkpoint**: The page loads, lists awaiting events with checkboxes, and lists reviewers — but cannot yet assign.
+
+---
+
+## Phase 3: User Story 1 - Assign a reviewer to awaiting events (single-reviewer deployment) (Priority: P1) 🎯 MVP
+
+**Goal**: An administrator selects awaiting events, picks one reviewer, confirms, and the events advance to `assigned` and leave the queue. Unblocks the scans upload→assign→review→done lifecycle.
+
+**Independent Test**: In a deployment with `REVIEWER_COUNT=1`, open the page, select one or more events, choose a reviewer, confirm — verify exactly one reviewer slot is shown, the events advance to `assigned`, a confirmation appears, and the events disappear from the queue.
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] In `frontend/src/pages/EventAssignMany.jsx`, render the first-reviewer `<select>` (always shown), populated from the fetched reviewers as `username (site)`. Drive slot rendering off `workflow.reviewer_count` so a single-reviewer deployment shows exactly one slot and no second/third slot (FR-008, FR-009).
+- [ ] T006 [US1] In `frontend/src/pages/EventAssignMany.jsx`, implement the confirm action for the single-reviewer path: `POST /api/events/assign_many` with body `{ event_ids, reviewer_id, slot: "first" }`. Disable the confirm button until at least one event is selected and a reviewer is chosen; indicate what is missing otherwise (FR-005, FR-007, FR-018).
+- [ ] T007 [US1] In `frontend/src/pages/EventAssignMany.jsx`, handle the assign response: on success show a confirmation via `showToast` (from `components/Toast`) and re-fetch the queue so assigned events leave it without a manual reload (FR-013, FR-014); on `400`/`401`/`403`/`500` surface the response's `error` message (or an auth/network message) as human-readable feedback and claim no success (FR-017, spec Edge Cases).
+
+**Checkpoint**: User Story 1 is fully functional — a single-reviewer deployment can assign reviewers end to end. **This is the MVP.**
+
+---
+
+## Phase 4: User Story 2 - Assign first and second reviewers (two-reviewer deployment) (Priority: P2)
+
+**Goal**: In a `REVIEWER_COUNT=2` deployment, an administrator assigns a first and a second (distinct) reviewer in one atomic action; the events advance out of the queue only when fully assigned.
+
+**Independent Test**: In a deployment with `REVIEWER_COUNT=2`, open the page, select events, choose two distinct reviewers, confirm — verify both reviewers are recorded and the events advance; verify choosing the same person for both slots blocks confirmation.
+
+> Backend tasks (T008–T011) and frontend tasks (T012–T013) touch different files and may be done by different developers in parallel; T013 is end-to-end testable only once the backend tasks land.
+
+### Tests for User Story 2
+
+- [ ] T008 [P] [US2] Add a backend test in `flask_backend/tests/test_table_service.py` (or a new `test_assign_many.py`) for the atomic two-reviewer path: assert `table_service.assign_events(event_ids, reviewer_id, "first", assigner_id, reviewer2_id=<id>)` sets `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and `status="assigned"` on every event; and assert `POST /api/events/assign_many` returns `400` when `reviewer2_id` is given with `reviewer_count==1`, with `slot != "first"`, and when `reviewer2_id == reviewer_id`. Write this before T009–T010 and confirm it fails first.
+
+### Implementation for User Story 2
+
+- [ ] T009 [US2] Extend `table_service.assign_events` in `flask_backend/table_service.py` with a trailing optional parameter `reviewer2_id=None`. When `slot == "first"` and `reviewer2_id` is provided, set `reviewer1_id`, `reviewer2_id`, `assigner_id`, `assign_date`, and `status = "assigned"` for all matched events within the single existing `session.commit()` (atomic). Existing positional callers are unaffected.
+- [ ] T010 [US2] Extend `events_assign_many` in `flask_backend/app.py` to read optional `reviewer2_id` from the request body and pass it to `assign_events`. Return `400` with a human-readable `error` when: `reviewer2_id` is present and `get_workflow_config().reviewer_count == 1`; `reviewer2_id` is present and `slot != "first"`; or `reviewer2_id == reviewer_id` (server-side FR-011). Update the endpoint docstring's Swagger block to document `reviewer2_id`.
+- [ ] T011 [US2] Regenerate the API contract: run `python -m flask_backend.generate_openapi` from the repository root and commit the updated `openapi.json` (Constitution quality gate).
+- [ ] T012 [US2] In `frontend/src/pages/EventAssignMany.jsx`, render the second-reviewer `<select>` only when `workflow.reviewer_count >= 2` (never a third slot — FR-010, FR-020). Require both slots filled before confirm is enabled (FR-012), and block confirmation with an explanatory message when the same person is selected in both slots (FR-011).
+- [ ] T013 [US2] In `frontend/src/pages/EventAssignMany.jsx`, send the two-reviewer assignment as a single request `{ event_ids, reviewer_id, slot: "first", reviewer2_id }` and surface the new `400` validation messages from T010 (FR-017). Reuse the success/queue-refresh handling from T007.
+
+**Checkpoint**: Both single-reviewer (US1) and two-reviewer (US2) deployments assign reviewers correctly and independently.
+
+---
+
+## Phase 5: User Story 3 - Narrow and page through the queue (Priority: P3)
+
+**Goal**: An administrator working with a large queue narrows it by site and pages through results.
+
+**Independent Test**: Open a queue spanning multiple pages with events from more than one site; apply a site filter and verify only that site's events show; page forward/back and verify the displayed set changes.
+
+### Implementation for User Story 3
+
+- [ ] T014 [US3] In `frontend/src/pages/EventAssignMany.jsx`, add a site-filter `<select>` whose options derive from the distinct `Site` values in the loaded queue rows (the View All Events pattern). On change, re-fetch the queue with the `site` query parameter and clear the current event selection so a confirm never acts on hidden events (FR-015, spec Edge Cases / Assumptions).
+- [ ] T015 [US3] In `frontend/src/pages/EventAssignMany.jsx`, add Previous/Next pagination (page size 20) driven by the endpoint's `total`, re-fetching with `limit`/`offset`; clear the event selection on page change (FR-016).
+
+**Checkpoint**: All three user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verification and quality gates across the whole feature.
+
+- [ ] T016 [P] Run `npm run lint` in `frontend/` and resolve any issues introduced in `EventAssignMany.jsx` and `MenuBar.jsx`.
+- [ ] T017 [P] Run `pytest flask_backend/tests/` and confirm the new T008 test passes and the existing `test_scans_workflow.py` and `test_full_workflow_defaults.py` still pass (the `assign_events` signature change is additive).
+- [ ] T018 Validate the feature against `specs/004-reviewer-assignment/quickstart.md`: single-reviewer path, two-reviewer path, error cases (no selection, not admin, server error, empty queue, no reviewers), and site filter + pagination.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: After Setup. **Blocks all user stories.**
+- **User Story 1 (Phase 3)**: After Foundational. The MVP.
+- **User Story 2 (Phase 4)**: After Foundational. Frontend tasks (T012–T013) extend US1's page code (same file); functionally independently testable in a `REVIEWER_COUNT=2` deployment.
+- **User Story 3 (Phase 5)**: After Foundational. Functionally independent of US1/US2; shares the page file so it serializes against their edits.
+- **Polish (Phase 6)**: After all desired user stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on Foundational. No dependency on US2 or US3.
+- **US2 (P2)**: Backend (T008–T011) depends only on Foundational. Frontend (T012–T013) builds on US1's selector/confirm code in the shared page file.
+- **US3 (P3)**: Depends only on Foundational. Independent of US1/US2 behavior.
+
+### File-level serialization (important)
+
+`frontend/src/pages/EventAssignMany.jsx` is edited by T003, T004, T005, T006, T007, T012, T013, T014, T015 — these **cannot run in parallel with each other**; do them in task-ID order. Genuine parallelism exists only across different files (see below).
+
+### Within Each User Story
+
+- US2: T008 (test) written first and expected to fail → T009 (service) → T010 (endpoint, depends on T009) → T011 (openapi regen, depends on T010). Frontend T012 → T013.
+
+---
+
+## Parallel Opportunities
+
+True parallelism is limited because most work is in one file. The real opportunities:
+
+- **T002** (`MenuBar.jsx`) is independent of every page-file task — run it any time during/after Foundational.
+- **US2 backend vs frontend**: T008/T009/T010/T011 (`flask_backend/*`, `openapi.json`) and T012/T013 (`EventAssignMany.jsx`) are different files — a two-developer split.
+- **T016** (frontend lint) and **T017** (backend pytest) are independent.
+
+```bash
+# Example: after Foundational, split US2 across two developers
+Developer A (backend): T008 → T009 → T010 → T011
+Developer B (frontend): T012 → T013   # after US1's page code (T005–T007) is in
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1: Setup (T001)
+2. Phase 2: Foundational (T002–T004)
+3. Phase 3: User Story 1 (T005–T007)
+4. **STOP and VALIDATE**: in a `REVIEWER_COUNT=1` deployment, assign reviewers end to end — this unblocks the scans lifecycle (SC-005).
+
+### Incremental Delivery
+
+1. Setup + Foundational → page loads with queue and reviewers.
+2. + US1 → single-reviewer assignment works → **MVP, deploy/demo.**
+3. + US2 → two-reviewer deployments supported (atomic backend extension).
+4. + US3 → site filter and pagination for large queues.
+5. Polish → lint, tests, quickstart validation.
+
+---
+
+## Notes
+
+- `[P]` = different file, no dependency on an incomplete task.
+- `[Story]` label maps each task to a spec user story for traceability.
+- The single-reviewer MVP (US1) is **frontend-only** — no backend change.
+- The backend change is **additive and backward-compatible**: existing `assign_many` callers (`pages/EventAssignThird.jsx`, backend tests) are unaffected.
+- Per Constitution Principle VI, `openapi.json` MUST be regenerated in the same change as the request-body extension (T011).
+- Commit after each task or logical group; stop at any checkpoint to validate a story independently.


### PR DESCRIPTION
"Build the interactive reviewer-assignment page for the event-validation workflow, replacing the current frontend/src/pages/EventAssignMany.jsx placeholder (today it shows only descriptive text and cannot perform an assignment)."