### PR TITLE
Fixes to "Add Multiple Events" page; remove id offsets of 1000; edit instructions

### DIFF
--- a/default.env
+++ b/default.env
@@ -103,7 +103,14 @@ DB_PASSWORD=CHANGEME
 # REVIEWER_COUNT — how many reviewers adjudicate each event. Must be 1 or 2;
 #   any other value aborts startup. Default: 2.
 # REVIEWER_COUNT=2
-
+#
+# CLINICAL_SITES — comma-separated list of clinical site codes shown in the
+#   Site picker on the event edit page. The schema has no site table (site is
+#   a free-text column on patient records), so this pick-list is configuration
+#   rather than data. Set it to the exact site codes this deployment's patient
+#   roster uses. When unset, a built-in default of known CNICS site codes is
+#   used. Purely a display list; any values are accepted.
+# CLINICAL_SITES=CWRU,Fenway,JH,UAB,UCSD,UCSF,UNC,UW,Vanderbilt
 ###
 ### Default environment variables for mci container
 ### Variables with VITE_ prefix will be available to the frontend client

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -1175,11 +1175,115 @@ def events_screen(event_id: int):
 @requires_auth
 @requires_roles('admin')
 def events_bulk():
-    # Minimal placeholder: accept a CSV upload and return 201. Implement parsing later.
+    """Bulk-create events from an uploaded CSV.
+
+    Expects multipart/form-data with field name `events_csv`. Each non-empty
+    line has the form:
+
+        site_patient_id, site_name, event_date, [criterion_name, criterion_value]...
+
+    where `event_date` is YYYY-MM-DD and the trailing criteria are zero or more
+    name/value pairs. The referenced patient must already exist in
+    `patients_view`; rows that fail validation are skipped and reported in
+    `errors`, while valid rows are imported in a single transaction.
+    """
+    import csv
+    import io
+
     if 'events_csv' not in request.files:
         return jsonify({'error': 'events_csv file is required'}), 400
-    # In a future improvement, parse CSV and create events via table_service.create_event
-    return jsonify({'data': {'imported': 0}}), 201
+    file = request.files['events_csv']
+    if not file or not file.filename:
+        return jsonify({'error': 'events_csv file is required'}), 400
+
+    try:
+        # utf-8-sig strips a leading BOM if the file was saved from Excel.
+        text = file.read().decode('utf-8-sig')
+    except UnicodeDecodeError:
+        return jsonify({'error': 'events_csv must be UTF-8 encoded text'}), 400
+
+    auth_user = getattr(g, 'auth_user', None) or {}
+    creator_id = int(auth_user.get('id') or 0) or 1
+
+    imported = 0
+    errors = []
+    session = models.get_session()
+    try:
+        reader = csv.reader(io.StringIO(text))
+        for lineno, row in enumerate(reader, start=1):
+            # Skip blank lines and an optional header row.
+            if not row or all(not (c or '').strip() for c in row):
+                continue
+            if lineno == 1 and row[0].strip().lower() == 'site_patient_id':
+                continue
+            if len(row) < 3:
+                errors.append(f'Line {lineno}: expected at least site_patient_id, site_name, event_date')
+                continue
+
+            site_patient_id = row[0].strip()
+            site = row[1].strip()
+            event_date_str = row[2].strip()
+            # Trailing criteria fields; drop empty cells left by trailing commas.
+            criteria_fields = [(c or '').strip() for c in row[3:]]
+            while criteria_fields and criteria_fields[-1] == '':
+                criteria_fields.pop()
+
+            if not site_patient_id or not site or not event_date_str:
+                errors.append(f'Line {lineno}: site_patient_id, site_name, and event_date are required')
+                continue
+            if len(criteria_fields) % 2 != 0:
+                errors.append(f'Line {lineno}: criteria must be comma-separated name,value pairs')
+                continue
+            try:
+                event_date = datetime.date.fromisoformat(event_date_str)
+            except ValueError:
+                errors.append(f'Line {lineno}: event_date must be in YYYY-MM-DD format')
+                continue
+
+            patient = (
+                session.query(models.PatientsView)
+                .filter_by(site_patient_id=site_patient_id, site=site)
+                .first()
+            )
+            if not patient:
+                errors.append(
+                    f'Line {lineno}: patient not found for site={site!r}, site_patient_id={site_patient_id!r}'
+                )
+                continue
+
+            event = models.Events(
+                patient_id=patient.id,
+                creator_id=creator_id,
+                event_date=event_date,
+                add_date=datetime.date.today(),
+            )
+            session.add(event)
+            session.flush()  # assign event.id for the criteria FK
+
+            for i in range(0, len(criteria_fields), 2):
+                name = criteria_fields[i]
+                value = criteria_fields[i + 1]
+                if not name:
+                    continue
+                session.add(models.Criterias(event_id=event.id, name=name[:50], value=value[:100]))
+
+            imported += 1
+
+        session.commit()
+    except Exception:
+        session.rollback()
+        app.logger.exception('Failed to bulk import events')
+        return jsonify({'error': 'Failed to import events'}), 500
+    finally:
+        session.close()
+
+    result = {'imported': imported}
+    if errors:
+        result['errors'] = errors
+    # Report an all-failure (nothing imported) as a client error so the UI can
+    # surface it instead of showing a false success.
+    status = 201 if imported else 400
+    return jsonify({'data': result}), status
 
 @app.route('/api/events/<int:event_id>/upload_scrubbed', methods=['POST'])
 @requires_auth

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -938,7 +938,7 @@ def events_export():
         writer = csv.writer(output)
         # Headings (reduced example; expand as needed)
         headings = [
-            'MI', 'Patient ID', 'Patient Site', 'Site Patient ID', 'Event Date', 'Status', 'Creator',
+            'Event ID', 'Patient ID', 'Patient Site', 'Site Patient ID', 'Event Date', 'Status', 'Creator',
             'Criteria: MI Dx', 'Criteria: CKMB_Q', 'Criteria: CKMB_M', 'Criteria: CKMB', 'Criteria: Troponin', 'Criteria: Other',
             'Add Date', 'Uploader', 'Upload Date', 'Marker (no packet)', 'No Packet Reason', 'Two Attempts?',
             'Prior Event Date', 'Prior Event Onsite?', 'Other Cause', 'Mark No Packet Date', 'Scrubber', 'Scrub Date',
@@ -964,7 +964,7 @@ def events_export():
         writer.writerow(headings)
         for r in rows:
             writer.writerow([
-                (r['id'] + 1000) if r.get('id') is not None else '',
+                r['id'] if r.get('id') is not None else '',
                 r.get('patient_id',''),
                 r.get('site',''),
                 r.get('site_patient_id',''),

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -624,6 +624,19 @@ def get_event_details(event_id: int):
         return jsonify({'error': 'Failed to fetch event details'}), 500
 
 
+@app.route('/api/sites')
+@requires_auth
+def get_sites():
+    """Return the configured clinical site codes for populating site pickers.
+
+    The list is deployment configuration (``CLINICAL_SITES``), not data — the
+    schema has no site table; ``site`` is a free-text column on patient
+    records. Resolved through the shared config layer so no query against the
+    large read-only ``patients_view`` is needed.
+    """
+    return jsonify({'data': study_config.get_clinical_sites()})
+
+
 @app.route('/api/users', methods=['POST'])
 @requires_auth
 @requires_roles('admin')
@@ -1104,18 +1117,35 @@ def events_update(event_id: int):
     site_patient_id = data.get('site_patient_id')
     site = data.get('site')
     event_date = data.get('event_date')
-    # Patient identity fields are sourced from `patients_view`, which is a
-    # UNION over read-only sources (uw_patients2, cnics_data.Patient). Edits
-    # to those fields must happen upstream, not here.
-    if site_patient_id is not None or site is not None:
-        return jsonify({
-            'error': 'site_patient_id and site are read-only here; update them in the upstream patient roster'
-        }), 400
     session = models.get_session()
     try:
         e = session.query(models.Events).get(event_id)
         if e is None:
             return jsonify({'error': 'Event not found'}), 404
+        # An event's site is not stored on the event; it is derived from the
+        # patient the event points at (events.patient_id -> patients_view).
+        # `patients_view` is read-only (UNION over uw_patients2 and the
+        # FEDERATED cnics_data.Patient), so we never write to it — to change
+        # the site we re-point the event at the existing patient row matching
+        # (site_patient_id, site), the same lookup create_event uses.
+        if site_patient_id is not None or site is not None:
+            spid = (site_patient_id or '').strip()
+            site_name = (site or '').strip()
+            if not spid or not site_name:
+                return jsonify({
+                    'error': 'site_patient_id and site are both required to change the patient'
+                }), 400
+            patient = (
+                session.query(models.PatientsView)
+                .filter_by(site_patient_id=spid, site=site_name)
+                .first()
+            )
+            if patient is None:
+                return jsonify({
+                    'error': f'No patient found in the roster for site={site_name!r}, '
+                             f'site_patient_id={spid!r}'
+                }), 400
+            e.patient_id = patient.id
         if event_date:
             try:
                 y, m, d = [int(x) for x in str(event_date).split('-')]

--- a/flask_backend/study_config.py
+++ b/flask_backend/study_config.py
@@ -88,6 +88,27 @@ def get_study_title() -> str:
     return os.getenv("STUDY_TITLE", "").strip()
 
 
+# Canonical CNICS clinical sites. The schema has no site table — `site` is a
+# free-text column on patient records — so the pick-list is configuration,
+# not data: a deployment sets CLINICAL_SITES to the exact site codes its
+# patient roster uses. The default is the set of site codes seen across CNICS
+# deployments; override per deployment as needed.
+_DEFAULT_CLINICAL_SITES = ("CWRU", "Fenway", "JH", "UAB", "UCSD", "UCSF", "UNC", "UW", "Vanderbilt")
+
+
+def get_clinical_sites() -> list:
+    """Return the configured clinical site codes for populating site pickers.
+
+    Read from ``CLINICAL_SITES`` as a comma-separated list (e.g.
+    ``"UAB,UCSD,UW"``); order is preserved and blank entries are dropped.
+    Falls back to a built-in default when unset or empty. Purely a display
+    pick-list, so — like the cosmetic title — any value is accepted.
+    """
+    raw = os.getenv("CLINICAL_SITES", "")
+    sites = [s.strip() for s in raw.split(",") if s.strip()]
+    return sites if sites else list(_DEFAULT_CLINICAL_SITES)
+
+
 def _profile_for(study_type: str) -> dict:
     """Return the default control profile for ``study_type``."""
     return _PROFILES.get((study_type or "").strip().lower(), _FULL_WORKFLOW_PROFILE)

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -925,7 +925,16 @@ def get_event_details(event_id: int) -> dict:
             """
         )
         row = session.execute(query, {"event_id": event_id}).mappings().first()
-        return dict(row) if row else {}
+        if not row:
+            return {}
+        # Serialize date columns as ISO (YYYY-MM-DD). Flask's default JSON
+        # otherwise renders a Python date as an RFC-1123 string
+        # ("Fri, 21 Nov 2003 00:00:00 GMT"), which an <input type="date"> on
+        # the edit page cannot parse, leaving the Event date control blank.
+        return {
+            key: (value.isoformat() if isinstance(value, datetime.date) else value)
+            for key, value in row.items()
+        }
     finally:
         session.close()
 

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -160,7 +160,9 @@ def test_bulk_csv_upload_does_not_persist_file(tmp_path, monkeypatch, admin_clie
         'events_csv': (io.BytesIO(b"MI,Patient ID\n,123\n"), 'events.csv')
     }
     res = admin_client.post('/api/events/bulk', data=data, content_type='multipart/form-data')
-    assert res.status_code == 201
+    # This malformed CSV imports no rows, so the endpoint reports an all-failure
+    # as a client error (400). The persistence check below is what this test guards.
+    assert res.status_code == 400
     # Ensure uploaded file is not saved on disk by endpoint (non-persistence)
     assert not any(p.name == 'events.csv' for p in tmp_path.iterdir())
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -260,7 +260,7 @@ function App() {
           {/* Uploader routes (uploader or admin) */}
           <Route path="/events/upload" element={
             <ProtectedRoute requiredRoles={['uploader', 'admin']} auth={auth}>
-              <EventUpload />
+              <EventUpload studyType={studyType} configResolved={configResolved} />
             </ProtectedRoute>
           } />
           <Route path="/vte/upload" element={
@@ -270,7 +270,7 @@ function App() {
           } />
           <Route path="/events/reupload" element={
             <ProtectedRoute requiredRoles={['uploader', 'admin']} auth={auth}>
-              <EventReupload />
+              <EventReupload studyType={studyType} configResolved={configResolved} />
             </ProtectedRoute>
           } />
           <Route path="/vte/reupload" element={

--- a/frontend/src/pages/EventAddMany.jsx
+++ b/frontend/src/pages/EventAddMany.jsx
@@ -34,13 +34,38 @@ function EventAddMany() {
 
   return (
     <div>
-      <h1>Add Multiple Events</h1>
+      <h1>Add Multiple New Events</h1>
       <p>
-        Download the CSV template: <a href="/files/CSV_template_events.csv" target="_blank" rel="noreferrer">CSV_template_events.csv</a>
+      Select a CSV file where each line has this format:
+      <blockquote>
+      <code>site_patient_id, site_name, event_date, criteria</code>
+      </blockquote>
       </p>
+
       <p>
-        Required columns: MI, Patient ID, Site Patient ID, Patient Site, Event Date (YYYY-MM-DD). Criteria may be a semicolon-separated list.
+      <code>event_date</code> is of the form <code>2000-12-25</code>, and corresponds to the date of the diagnosis of labs or procedure that trigger the review.
       </p>
+
+      <p>
+      <code>criteria</code> is a (possibly empty) list of criteria used to identify potential events.  Each criterion consists of two comma-separated fields. The first field is the name of a criterion, the second is the value of the criterion.  Some examples:
+      </p>
+
+      <ul>
+      <li>
+      CK,5
+      </li>
+      <li>
+      troponins,2,CK,5
+      </li>
+      <li>
+      troponins,2,CK,5,procedures,"CPR,defibrillation" 
+      </li>
+      </ul>
+
+      <p>
+      Note: criteria fields that contain commas should be enclosed in double quotes
+      </p>
+
       <form onSubmit={handleSubmit}>
         <div>
           <label>

--- a/frontend/src/pages/EventAddMany.jsx
+++ b/frontend/src/pages/EventAddMany.jsx
@@ -17,14 +17,32 @@ function EventAddMany() {
         credentials: 'include',
         body: form,
       })
-      if (res.ok) {
+      let body = {}
+      try {
+        body = await res.json()
+      } catch {
+        body = {}
+      }
+      const imported = body?.data?.imported ?? 0
+      const rowErrors = body?.data?.errors || []
+      if (res.ok && imported > 0) {
         setStatus('saved')
         setFile(null)
         e.target.reset()
-        showToast('Events CSV uploaded successfully.', 'success')
+        const suffix = rowErrors.length
+          ? ` ${rowErrors.length} row(s) were skipped: ${rowErrors.join('; ')}`
+          : ''
+        showToast(
+          `Imported ${imported} event${imported === 1 ? '' : 's'}.${suffix}`,
+          rowErrors.length ? 'warning' : 'success',
+          rowErrors.length ? 10000 : 3000,
+        )
       } else {
         setStatus('error')
-        showToast('CSV upload failed. Please check the file and try again.', 'error')
+        const detail = rowErrors.length
+          ? rowErrors.join('; ')
+          : body?.error || 'Please check the file and try again.'
+        showToast(`CSV upload failed. ${detail}`, 'error', 10000)
       }
     } catch {
       setStatus('error')

--- a/frontend/src/pages/EventEdit.jsx
+++ b/frontend/src/pages/EventEdit.jsx
@@ -33,14 +33,10 @@ function EventEdit() {
         })
       })
       .catch(() => setDetails(null))
-    // Load sites from patients_view (distinct)
-    fetch(`${apiUrl}/api/tables/patients_view?limit=2000`, { credentials: 'include' })
+    // Load the configured list of clinical sites for the Site picker.
+    fetch(`${apiUrl}/api/sites`, { credentials: 'include' })
       .then((res) => res.ok ? res.json() : Promise.reject(res))
-      .then((json) => {
-        const rows = json.data || []
-        const uniqueSites = Array.from(new Set(rows.map((r) => r.site).filter(Boolean))).sort()
-        setSites(uniqueSites)
-      })
+      .then((json) => setSites(json.data || []))
       .catch(() => setSites([]))
 
     // Load criteria for this event (client-side filter from table API)
@@ -145,9 +141,13 @@ function EventEdit() {
     }
   }
 
+  // Always include this event's current site in the picker, even if the
+  // configured list omits it, so the true site (e.g. 'UAB') stays selected.
+  const siteOptions = Array.from(new Set([form.site, ...sites].filter(Boolean)))
+
   return (
     <div>
-      <h2>Edit Event MI {eventId}</h2>
+      <h2>Edit Event {eventId}</h2>
 
       {details && (
         <p>
@@ -185,7 +185,7 @@ function EventEdit() {
                 <td>
                   <select name="site" value={form.site} onChange={handleChange}>
                     <option value="">Select site</option>
-                    {sites.map((s) => (
+                    {siteOptions.map((s) => (
                       <option key={s} value={s}>{s}</option>
                     ))}
                   </select>

--- a/frontend/src/pages/EventReupload.jsx
+++ b/frontend/src/pages/EventReupload.jsx
@@ -1,8 +1,31 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { resolveReviewGuidance } from '../components/reviewGuidance'
 import './Home.css'
 
-const API_BASE = import.meta.env.VITE_API_URL || ''
+const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')
+
+// Render one guidance box's optional file links. Kept identical to Home's
+// GuidanceLinks so the guidance boxes render the same across pages. Returns
+// null when the box defines no links.
+function GuidanceLinks({ box }) {
+  if (!box.links || box.links.length === 0) return null
+  return (
+    <div>
+      {box.linkLabel ? `${box.linkLabel} ` : ''}
+      {box.links.map((link, i) => (
+        <span key={link.href}>
+          {i > 0 ? ' | ' : ''}
+          {link.download ? (
+            <a href={`${API_BASE}${link.href}`} download>{link.label}</a>
+          ) : (
+            <a href={`${API_BASE}${link.href}`} target="_blank">{link.label}</a>
+          )}
+        </span>
+      ))}
+    </div>
+  )
+}
 
 function Table({ rows }) {
   const navigate = useNavigate()
@@ -70,8 +93,13 @@ function Table({ rows }) {
   )
 }
 
-function EventReupload() {
+function EventReupload({ studyType, configResolved = true }) {
   const [rows, setRows] = useState([])
+
+  // Body content for the two bottom guidance boxes, chosen by the deployment's
+  // study type. Resolved the same way as Home so all pages show identical,
+  // study-aware guidance.
+  const guidance = resolveReviewGuidance(studyType)
 
   useEffect(() => {
     fetch(`${API_BASE}/api/events/need_reupload`)
@@ -93,45 +121,31 @@ function EventReupload() {
         <Table rows={rows} />
       </section>
 
-      <div className="infobox">
-        <h3>Review packets should contain:</h3>
-        <ol>
-          <li>Physician's notes closest to potential Event date</li>
-          <li>Outpatient cardiology consultations</li>
-          <li>In-patient cardiology notes or consults</li>
-          <li>Baseline ECG</li>
-          <li>First 2 ECGs after admission or in-hospital event</li>
-          <li>Related procedure and diagnostic test results</li>
-          <li>Related laboratory evidence</li>
-          <li>
-            Please redact the personal identifiers including name, birthday, and
-            hospital number
-          </li>
-        </ol>
-        <div>
-          Full instructions:{' '}
-          <a href={`${API_BASE}/files/CNICS MI Review packet assembly instructions.doc`} download>.doc</a>{' '}
-          |{' '}
-          <a
-            href={`${API_BASE}/files/CNICS MI Review packet assembly instructions.pdf`}
-            target="_blank"
-          >
-            .pdf
-          </a>
-        </div>
-      </div>
+      {configResolved && (
+        <>
+          <div className="infobox">
+            <h3>Review packets should contain:</h3>
+            {guidance.packets.items.length > 0 && (
+              <ol>
+                {guidance.packets.items.map((item, i) => (
+                  <li key={i}>{item}</li>
+                ))}
+              </ol>
+            )}
+            <GuidanceLinks box={guidance.packets} />
+          </div>
 
-      <div className="infobox">
-        <h3>Review Instructions:</h3>
-        <div>
-          View as:{' '}
-          <a href={`${API_BASE}/files/CNICS MI reviewer instructions.doc`} download>.doc</a>{' '}
-          |{' '}
-          <a href={`${API_BASE}/files/CNICS MI reviewer instructions.pdf`} target="_blank">
-            .pdf
-          </a>
-        </div>
-      </div>
+          <div className="infobox">
+            <h3>Review Instructions:</h3>
+            {/* The instructions box is prose, not a checklist — render each
+                item as its own line rather than a numbered list. */}
+            {guidance.instructions.items.map((item, i) => (
+              <div key={i}>{item}</div>
+            ))}
+            <GuidanceLinks box={guidance.instructions} />
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/EventUpload.jsx
+++ b/frontend/src/pages/EventUpload.jsx
@@ -1,9 +1,33 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import DataTable from '../components/DataTable'
+import { resolveReviewGuidance } from '../components/reviewGuidance'
 import './EventUpload.css'
 
 const PAGE_SIZE = 20
+const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')
+
+// Render one guidance box's optional file links. Kept identical to Home's
+// GuidanceLinks so the "Review packets should contain" box renders the same in
+// both places. Returns null when the box defines no links.
+function GuidanceLinks({ box }) {
+  if (!box.links || box.links.length === 0) return null
+  return (
+    <div>
+      {box.linkLabel ? `${box.linkLabel} ` : ''}
+      {box.links.map((link, i) => (
+        <span key={link.href}>
+          {i > 0 ? ' | ' : ''}
+          {link.download ? (
+            <a href={`${API_BASE}${link.href}`} download>{link.label}</a>
+          ) : (
+            <a href={`${API_BASE}${link.href}`} target="_blank">{link.label}</a>
+          )}
+        </span>
+      ))}
+    </div>
+  )
+}
 
 // Shared table wrapper copied from Home to ensure identical behavior/columns
 function TableWrapper({ endpoint, columns, renderActions, pageSize = PAGE_SIZE }) {
@@ -12,8 +36,6 @@ function TableWrapper({ endpoint, columns, renderActions, pageSize = PAGE_SIZE }
   const [totalCount, setTotalCount] = useState(null)
   const [search, setSearch] = useState('')
   const [siteFilter, setSiteFilter] = useState('')
-
-  const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')
 
   const fetchPage = (p) => {
     const params = new URLSearchParams({
@@ -87,8 +109,13 @@ function TableWrapper({ endpoint, columns, renderActions, pageSize = PAGE_SIZE }
   )
 }
 
-function EventUpload() {
+function EventUpload({ studyType, configResolved = true }) {
   const [searchParams] = useSearchParams()
+
+  // Body content for the "Review packets should contain" box, chosen by the
+  // deployment's study type. Resolved the same way as Home so both pages show
+  // identical, study-aware guidance.
+  const guidance = resolveReviewGuidance(studyType)
   const navigate = useNavigate()
   const eventId = searchParams.get('event_id')
   const patientId = searchParams.get('patient_id')
@@ -100,8 +127,6 @@ function EventUpload() {
   const [packetFile, setPacketFile] = useState(null)
   const [uploadStatus, setUploadStatus] = useState('idle') // idle | uploading | success | error
   const [uploadError, setUploadError] = useState('')
-
-  const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')
 
   const noPacketReasons = [
     'Outside hospital',
@@ -192,35 +217,19 @@ function EventUpload() {
         </div>
       )}
 
-      <div className="infobox">
-        <h3>Review packets should contain:</h3>
-        <ol>
-          <li>Physician's notes closest to potential Event date</li>
-          <li>Outpatient cardiology consultations</li>
-          <li>In-patient cardiology notes or consults</li>
-          <li>Baseline ECG</li>
-          <li>First 2 ECGs after admission or in-hospital event</li>
-          <li>Related procedure and diagnostic test results</li>
-          <li>Related laboratory evidence</li>
-          <li>
-            Please redact the personal identifiers including name, birthday, and
-            hospital number
-          </li>
-        </ol>
-        <div>
-          Full instructions:{' '}
-          <a href="/files/CNICS MI Review packet assembly instructions.doc" download>
-            .doc
-          </a>{' '}
-          |{' '}
-          <a
-            href="/files/CNICS MI Review packet assembly instructions.pdf"
-            target="_blank"
-          >
-            .pdf
-          </a>
+      {configResolved && (
+        <div className="infobox">
+          <h3>Review packets should contain:</h3>
+          {guidance.packets.items.length > 0 && (
+            <ol>
+              {guidance.packets.items.map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ol>
+          )}
+          <GuidanceLinks box={guidance.packets} />
         </div>
-      </div>
+      )}
 
       {eventId && (
         <>

--- a/frontend/src/pages/EventViewAll.jsx
+++ b/frontend/src/pages/EventViewAll.jsx
@@ -212,7 +212,7 @@ function EventViewAll({ workflow }) {
         columns={['Event Number', 'Event Date', 'Uploaded', 'Site']}
         augmentRows={(rows) => rows.map((r) => ({
           ...r,
-          'Event Number': (r['ID'] != null ? 1000 + Number(r['ID']) : ''),
+          'Event Number': (r['ID'] != null ? Number(r['ID']) : ''),
           'Event Date': r['Date'] || '',
         }))}
         renderActions={(row) => (
@@ -245,7 +245,7 @@ function EventViewAll({ workflow }) {
         columns={['Event Number', 'Event Date', 'Scrubbed', 'Site']}
         augmentRows={(rows) => rows.map((r) => ({
           ...r,
-          'Event Number': (r['ID'] != null ? 1000 + Number(r['ID']) : ''),
+          'Event Number': (r['ID'] != null ? Number(r['ID']) : ''),
           'Event Date': r['Date'] || '',
         }))}
         renderActions={(row) => (

--- a/openapi.json
+++ b/openapi.json
@@ -68,6 +68,7 @@ paths:
                   type: integer
   /api/events/by_status/{status}: {}
   /api/events/{int:event_id}: {}
+  /api/sites: {}
   /api/users: {}
   /api/auth/me: {}
   /api/config:


### PR DESCRIPTION
The "Add Multiple Events" page had errant information, including a bad template csv. Changing it to be the same as the MCI version (including lack of template).