### PR TITLE
Address issue raised by Liz: fields not populated at /events/upload?event_id=[n]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # cnics-validation Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-05
+Auto-generated from all feature plans. Last updated: 2026-08-13
 
 ## Active Technologies
 - N/A — documentation, Markdown, and inline comments + None added. `python-keycloak` is retained (already (002-constitution-sync)
@@ -14,6 +14,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-05
 - N/A — no persisted data; section visibility is derived from runtime workflow config (006-study-aware-event-actions)
 - JavaScript / JSX, React 19 (frontend); no backend change + react-router-dom 6, Vite 7 (build/dev) — no new dependency (007-study-aware-review-sections)
 - N/A — content is static, derived from runtime `STUDY_TYPE` config; no persisted data (007-study-aware-review-sections)
+- Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend) + Flask, SQLAlchemy, mysql-connector-python; React 19, react-router-dom 6, Vite 7 — **no new dependency** (008-upload-event-identifiers)
+- MariaDB 10.11, shared schema under `init/`. **No schema change in this feature** — all four values already exist and are populated (008-upload-event-identifiers)
 
 - N/A — no code in a programming language is being + N/A. The repository's runtime stack (Flask + (001-mark-fhir-unused)
 
@@ -34,9 +36,9 @@ tests/
 N/A — no code in a programming language is being: Follow standard conventions
 
 ## Recent Changes
+- 008-upload-event-identifiers: Added Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend) + Flask, SQLAlchemy, mysql-connector-python; React 19, react-router-dom 6, Vite 7 — **no new dependency**
 - 007-study-aware-review-sections: Added JavaScript / JSX, React 19 (frontend); no backend change + react-router-dom 6, Vite 7 (build/dev) — no new dependency
 - 006-study-aware-event-actions: Added JavaScript / JSX, React 19 + react-router-dom 6, Vite 7 (build/dev); no new dependency
-- 005-banner-restyle: Added JavaScript / JSX, React 19 + react-router-dom 6, Vite 7 (build/dev); no new dependency
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -614,6 +614,51 @@ def events_by_status(status: str):
 @app.route('/api/events/<int:event_id>')
 @requires_auth
 def get_event_details(event_id: int):
+    """Return one event with its patient identifiers and ascertainment criteria.
+
+    The packet-upload page cross-references these values against the packet in
+    hand before accepting a file, so `patient_id`, `site_patient_id`,
+    `event_date`, and `criteria` are all served from the stored record rather
+    than passed between pages in the query string.
+    ---
+    responses:
+      200:
+        description: Event details
+        schema:
+          type: object
+          properties:
+            data:
+              type: object
+              properties:
+                id:
+                  type: integer
+                patient_id:
+                  type: integer
+                site_patient_id:
+                  type: string
+                site:
+                  type: string
+                status:
+                  type: string
+                event_date:
+                  type: string
+                  description: ISO date (YYYY-MM-DD)
+                criteria:
+                  type: array
+                  description: >
+                    Ascertainment criteria for this event, ordered by name then
+                    id. Always present; an empty list when the event has none,
+                    which is a legitimate state since criteria are optional.
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+      404:
+        description: No such event
+    """
     try:
         details = table_service.get_event_details(event_id)
         if not details:

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -872,10 +872,12 @@ def send_events(event_ids: list[int], sender_id: int) -> dict:
         session.close()
 
 def get_event_details(event_id: int) -> dict:
-    """Return a single event with related usernames and patient identifiers.
+    """Return a single event with related usernames, patient identifiers, and criteria.
 
     Includes core dates, status, creator/uploader/screener/assigner/sender usernames,
-    and patient `site_patient_id` and `site`.
+    patient `site_patient_id` and `site`, and the event's ascertainment `criteria`
+    as a list of ``{"name": ..., "value": ...}`` dicts (``[]`` when the event has
+    none).
     """
     session = get_session()
     try:
@@ -927,14 +929,36 @@ def get_event_details(event_id: int) -> dict:
         row = session.execute(query, {"event_id": event_id}).mappings().first()
         if not row:
             return {}
+        # Criteria are fetched separately rather than joined above. Joining
+        # `criterias` would multiply the single event row by the criteria count,
+        # and GROUP_CONCAT cannot carry structured pairs safely: `name` and
+        # `value` are free text, so any delimiter we picked could appear inside
+        # them. The table is indexed on event_id, so this is one indexed read.
+        criteria_rows = session.execute(
+            text(
+                """
+                SELECT c.name AS name, c.value AS value
+                FROM criterias c
+                WHERE c.event_id = :event_id
+                ORDER BY c.name, c.id
+                """
+            ),
+            {"event_id": event_id},
+        ).mappings().all()
         # Serialize date columns as ISO (YYYY-MM-DD). Flask's default JSON
         # otherwise renders a Python date as an RFC-1123 string
         # ("Fri, 21 Nov 2003 00:00:00 GMT"), which an <input type="date"> on
         # the edit page cannot parse, leaving the Event date control blank.
-        return {
+        details = {
             key: (value.isoformat() if isinstance(value, datetime.date) else value)
             for key, value in row.items()
         }
+        # Always a list, never None, so the upload page has one shape to render
+        # for "this event has no criteria" (which is a legitimate state).
+        details["criteria"] = [
+            {"name": c["name"], "value": c["value"]} for c in criteria_rows
+        ]
+        return details
     finally:
         session.close()
 

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import MagicMock, patch
 import flask_backend.table_service as ts
 
@@ -196,3 +197,137 @@ def test_create_user(mock_get_session, mock_users):
         admin_flag=1,
     )
     assert result['id'] == 1
+
+
+def _event_details_session(event_row, criteria_rows):
+    """Build a mock session for get_event_details, which runs two queries.
+
+    The first fetches the single event row (.mappings().first()); the second
+    fetches its criteria (.mappings().all()).
+    """
+    event_result = MagicMock()
+    event_result.mappings.return_value.first.return_value = event_row
+    criteria_result = MagicMock()
+    criteria_result.mappings.return_value.all.return_value = criteria_rows
+
+    mock_session = MagicMock()
+    mock_session.execute.side_effect = [event_result, criteria_result]
+    return mock_session
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_details_returns_criteria_name_and_value(mock_get_session):
+    """Criteria come back as structured pairs, ordered by name then id."""
+    mock_get_session.return_value = _event_details_session(
+        {'id': 7, 'patient_id': 3},
+        [
+            {'name': 'ECG', 'value': 'ST elevation'},
+            {'name': 'Troponin', 'value': '0.42 ng/mL'},
+        ],
+    )
+
+    details = ts.get_event_details(7)
+
+    assert details['criteria'] == [
+        {'name': 'ECG', 'value': 'ST elevation'},
+        {'name': 'Troponin', 'value': '0.42 ng/mL'},
+    ]
+    # The ordering is applied in SQL, not on the client, so assert the query
+    # asks for it. FR-008 requires a total order that cannot vary between loads.
+    criteria_query = str(mock_session_query(mock_get_session, index=1))
+    assert 'FROM criterias' in criteria_query
+    assert 'ORDER BY c.name, c.id' in criteria_query
+
+
+def mock_session_query(mock_get_session, index):
+    """Return the SQL text of the Nth execute() call on the mocked session."""
+    return mock_get_session.return_value.execute.call_args_list[index].args[0]
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_details_criteria_query_is_scoped_to_the_event(mock_get_session):
+    """The criteria lookup filters on event_id rather than fetching all rows."""
+    mock_get_session.return_value = _event_details_session({'id': 7}, [])
+
+    ts.get_event_details(7)
+
+    params = mock_get_session.return_value.execute.call_args_list[1].args[1]
+    assert params == {'event_id': 7}
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_details_duplicate_criteria_names_order_deterministically(
+    mock_get_session,
+):
+    """Two criteria sharing a name still come back in a stable order."""
+    mock_get_session.return_value = _event_details_session(
+        {'id': 7},
+        [
+            {'name': 'Troponin', 'value': '0.10 ng/mL'},
+            {'name': 'Troponin', 'value': '0.42 ng/mL'},
+        ],
+    )
+
+    details = ts.get_event_details(7)
+
+    assert [c['value'] for c in details['criteria']] == ['0.10 ng/mL', '0.42 ng/mL']
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_details_no_criteria_returns_empty_list(mock_get_session):
+    """An event with no criteria yields [] and never None.
+
+    Criteria are optional, so this is a legitimate state; the upload page must
+    have one shape to render for it and must stay uploadable (FR-006b).
+    """
+    mock_get_session.return_value = _event_details_session({'id': 7}, [])
+
+    details = ts.get_event_details(7)
+
+    assert details['criteria'] == []
+    assert details['criteria'] is not None
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_details_preserves_existing_keys(mock_get_session):
+    """Regression guard: the criteria addition must be purely additive.
+
+    EventScrub and EventScreen consume this same payload; if any pre-existing
+    key changed name, type, or serialization, those pages would break.
+    """
+    mock_get_session.return_value = _event_details_session(
+        {
+            'id': 7,
+            'patient_id': 3,
+            'site_patient_id': 'UW-00412',
+            'site': 'UW',
+            'status': 'created',
+            'event_date': datetime.date(2026, 3, 14),
+            'upload_date': None,
+            'uploader_username': None,
+        },
+        [{'name': 'ECG', 'value': 'ST elevation'}],
+    )
+
+    details = ts.get_event_details(7)
+
+    assert details['id'] == 7
+    assert details['patient_id'] == 3
+    assert details['site_patient_id'] == 'UW-00412'
+    assert details['site'] == 'UW'
+    assert details['status'] == 'created'
+    assert details['upload_date'] is None
+    assert details['uploader_username'] is None
+    # Dates stay ISO-serialized, which is what the date controls elsewhere parse.
+    assert details['event_date'] == '2026-03-14'
+
+
+@patch('flask_backend.table_service.models.get_session')
+def test_get_event_details_missing_event_returns_empty_dict(mock_get_session):
+    """A nonexistent event short-circuits before the criteria query runs."""
+    mock_get_session.return_value = _event_details_session(None, [])
+
+    details = ts.get_event_details(999)
+
+    assert details == {}
+    assert mock_get_session.return_value.execute.call_count == 1

--- a/frontend/src/pages/EventReupload.jsx
+++ b/frontend/src/pages/EventReupload.jsx
@@ -64,9 +64,9 @@ function Table({ rows }) {
               key={idx}
               className="clickable"
               onClick={() =>
-                navigate(
-                  `/events/upload?event_id=${row['ID']}&patient_id=${row['Patient ID']}&date=${row['Date']}&criteria=${encodeURIComponent(row['Criteria'])}`
-                )
+                // Event id only; the upload page loads the identifying values
+                // from the stored record.
+                navigate(`/events/upload?event_id=${row['ID']}`)
               }
             >
               {headers.map((h) => (

--- a/frontend/src/pages/EventUpload.jsx
+++ b/frontend/src/pages/EventUpload.jsx
@@ -6,6 +6,9 @@ import './EventUpload.css'
 
 const PAGE_SIZE = 20
 const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || '')
+// Placeholder for a value the record legitimately does not carry. Matches the
+// convention already used on the scrub and screen pages.
+const EMPTY_VALUE = '—'
 
 // Render one guidance box's optional file links. Kept identical to Home's
 // GuidanceLinks so the "Review packets should contain" box renders the same in
@@ -74,9 +77,10 @@ function TableWrapper({ endpoint, columns, renderActions, pageSize = PAGE_SIZE }
   }, [search, siteFilter])
 
   const handleClick = (row) => {
-    navigate(
-      `/events/upload?event_id=${row['ID']}&patient_id=${row['Patient ID']}&date=${row['Date']}&criteria=${encodeURIComponent(row['Criteria'])}`
-    )
+    // Only the event id travels in the link. The upload page reads the
+    // identifying values from the stored record, so passing them here would be
+    // both redundant and a source of staleness.
+    navigate(`/events/upload?event_id=${row['ID']}`)
   }
   const sites = Array.from(
     new Set(rows.map((r) => r['Site'] || r['site']).filter(Boolean))
@@ -117,10 +121,12 @@ function EventUpload({ studyType, configResolved = true }) {
   // identical, study-aware guidance.
   const guidance = resolveReviewGuidance(studyType)
   const navigate = useNavigate()
+  // `event_id` is the only query parameter this page reads. The identifying
+  // values are fetched from the stored record below, so a link, a bookmark, and
+  // the row action button all render the same thing. Older links may still
+  // carry patient_id/date/criteria; those are ignored, not rejected.
   const eventId = searchParams.get('event_id')
-  const patientId = searchParams.get('patient_id')
-  const date = searchParams.get('date')
-  const criteria = searchParams.get('criteria')
+  const [details, setDetails] = useState(null)
   // State for the upload UI only (search/table browsing removed to match Home)
   const [noPacketReason, setNoPacketReason] = useState('')
   const [priorEventDateKnown, setPriorEventDateKnown] = useState('')
@@ -143,6 +149,22 @@ function EventUpload({ studyType, configResolved = true }) {
   // No homepage-style preloading or local search; use the shared TableWrapper instead
 
   // Removed client-side table browsing/filtering
+
+  // Load the event's identifying details so the uploader can cross-reference
+  // them against the packet in hand before attaching a file. Mirrors the fetch
+  // in EventScrub. No request is made when browsing the list (no event_id).
+  useEffect(() => {
+    if (!eventId) return
+    fetch(`${API_BASE}/api/events/${encodeURIComponent(eventId)}`, {
+      credentials: 'include',
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('load')
+        return res.json()
+      })
+      .then((json) => setDetails(json.data || null))
+      .catch(() => setDetails(null))
+  }, [eventId])
 
   const handleUploadSubmit = async (e) => {
     e.preventDefault()
@@ -208,12 +230,24 @@ function EventUpload({ studyType, configResolved = true }) {
         </section>
       )}
 
-      {eventId && (
+      {eventId && details && (
         <div className="infobox">
           <div>Packet for MI {eventId}</div>
-          <div>Patient ID: {patientId}</div>
-          <div>Date: {date}</div>
-          <div>Criteria: {criteria}</div>
+          {/* Patient ID and Site Patient ID are labelled separately on purpose:
+              the uploader cross-references the site's own identifier against
+              the packet, so collapsing the two into one line would defeat the
+              check this box exists for. */}
+          <div>Patient ID: {details.patient_id}</div>
+          <div>Site Patient ID: {details.site_patient_id}</div>
+          <div>Date: {details.event_date}</div>
+          <div>
+            Criteria:{' '}
+            {details.criteria && details.criteria.length > 0
+              ? details.criteria
+                  .map((c) => `${c.name}: ${c.value || EMPTY_VALUE}`)
+                  .join(', ')
+              : EMPTY_VALUE}
+          </div>
         </div>
       )}
 

--- a/openapi.json
+++ b/openapi.json
@@ -67,7 +67,46 @@ paths:
                 additionalProperties:
                   type: integer
   /api/events/by_status/{status}: {}
-  /api/events/{int:event_id}: {}
+  /api/events/{int:event_id}:
+    get:
+      responses:
+        '200':
+          description: Event details
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  patient_id:
+                    type: integer
+                  site_patient_id:
+                    type: string
+                  site:
+                    type: string
+                  status:
+                    type: string
+                  event_date:
+                    type: string
+                    description: ISO date (YYYY-MM-DD)
+                  criteria:
+                    type: array
+                    description: 'Ascertainment criteria for this event, ordered by
+                      name then id. Always present; an empty list when the event has
+                      none, which is a legitimate state since criteria are optional.
+
+                      '
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+        '404':
+          description: No such event
   /api/sites: {}
   /api/users: {}
   /api/auth/me: {}

--- a/specs/008-upload-event-identifiers/checklists/requirements.md
+++ b/specs/008-upload-event-identifiers/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Populate event identifiers on the upload page
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1: initial draft used route names and endpoint paths in several requirements. Rewritten to describe entry routes and stored records in user terms. Success criteria rephrased away from response-time targets toward user-perceptible outcomes.
+- Validation iteration 2: both clarifications resolved by the user.
+  - Q1 (upload gating) was answered by a data-model fact rather than by choosing an option: internal Patient ID, Site Patient ID, and event date are all mandatory upstream before an event can be created; criteria are optional. This splits the former single "missing value" case in two — absence of a required identifier is a verification failure (FR-006, FR-010, FR-011), absence of criteria is ordinary and must not obstruct upload (FR-006a, FR-006b). FR-011 now blocks acceptance of a packet whenever the details could not be displayed, with FR-011a covering retry after a transient failure.
+  - Q2 (criteria format) resolved to name-and-value pairs (FR-008, FR-012). The upload page therefore shows more detail than the "Criteria" column on the events lists, which shows names only — recorded as a deliberate divergence in Assumptions.
+- All checklist items pass. Spec is ready for `/speckit.plan`.

--- a/specs/008-upload-event-identifiers/contracts/event-details.md
+++ b/specs/008-upload-event-identifiers/contracts/event-details.md
@@ -1,0 +1,95 @@
+# Contract: `GET /api/events/{event_id}`
+
+**Feature**: `008-upload-event-identifiers`
+**Change type**: Additive — one new key in an existing response. No key is
+removed, renamed, or retyped.
+
+Pre-release per Constitution Principle VI, so no deprecation window is needed.
+`openapi.json` MUST be regenerated in the same PR
+(`python -m flask_backend.generate_openapi`, from the repository root).
+
+## Route
+
+| | |
+|---|---|
+| Method | `GET` |
+| Path | `/api/events/<int:event_id>` |
+| Handler | `flask_backend/app.py:614` `get_event_details` |
+| Auth | `@requires_auth` — **unchanged** (see research D5) |
+| Roles | None declared — **unchanged**. Pre-existing gap, documented as follow-up, deliberately not altered here |
+
+## Response — 200
+
+```jsonc
+{
+  "data": {
+    "id": 4711,
+    "patient_id": 1832,
+    "site_patient_id": "UW-00412",
+    "site": "UW",
+    "status": "created",
+    "event_date": "2026-03-14",
+    "add_date": "2026-03-15",
+    "upload_date": null,
+
+    // ...remaining existing date and *_username keys, unchanged...
+
+    // NEW — added by this feature
+    "criteria": [
+      { "name": "Troponin",   "value": "0.42 ng/mL" },
+      { "name": "ECG",        "value": "ST elevation" }
+    ]
+  }
+}
+```
+
+### `criteria` — new key
+
+| Property | Contract |
+|---|---|
+| Type | Array of objects. Always present |
+| Empty case | `[]` when the event has no criteria. Never `null`, never omitted |
+| `name` | String. From `criterias.name` (`varchar(50)`, NOT NULL) |
+| `value` | String. From `criterias.value` (`varchar(100)`, NOT NULL) |
+| Order | `name` ascending, then `id` ascending. Total and stable across calls (FR-008) |
+
+The `name` ordering matches `GROUP_CONCAT(c.name ORDER BY c.name ...)` in the
+list queries (`flask_backend/table_service.py:154`), so criteria appear in the
+same sequence on the upload page as in the events lists' `Criteria` column.
+
+## Response — 404
+
+Unchanged. Returned when no event has that id (`app.py:619-620`).
+
+```json
+{ }
+```
+
+Consumed by this feature as a verification failure: the upload page shows a
+not-found message and withholds the upload control (FR-010, FR-011).
+
+## Response — 500
+
+Unchanged shape.
+
+```json
+{ "error": "Failed to fetch event details" }
+```
+
+Treated by the upload page as a transient failure — message plus retry, upload
+withheld until it succeeds (FR-011a).
+
+## Consumers
+
+| Consumer | Impact |
+|---|---|
+| `frontend/src/pages/EventUpload.jsx` | **New consumer.** Reads `patient_id`, `site_patient_id`, `event_date`, `criteria` |
+| `frontend/src/pages/EventScrub.jsx:17` | Unaffected — additive change; ignores the new key |
+| `frontend/src/pages/EventScreen.jsx` | Unaffected — same |
+| `frontend/src/studies/vte/*` | Out of scope. VTE fork is not extended (spec Assumptions) |
+
+## Backward compatibility
+
+Legacy CNICS/CakePHP consumers are unaffected: this is one of the React/Flask
+app's own routes, not a legacy contract, and the change adds a key rather than
+altering any existing one. Principle III is not engaged.

--- a/specs/008-upload-event-identifiers/contracts/upload-page-ui.md
+++ b/specs/008-upload-event-identifiers/contracts/upload-page-ui.md
@@ -1,0 +1,108 @@
+# Contract: Upload page UI states
+
+**Feature**: `008-upload-event-identifiers`
+**Surface**: `/events/upload` — `frontend/src/pages/EventUpload.jsx`
+
+The page has one existing behavior (no `event_id` → browse a list) and, for a
+named event, four mutually exclusive states. Today only one exists, and it
+renders whatever the address bar happened to carry.
+
+## State machine
+
+```text
+                    ┌─────────────────────────────────────┐
+   no event_id ────▶│ BROWSE — events-needing-packets list │  (unchanged)
+                    └─────────────────────────────────────┘
+
+   event_id present
+        │
+        ▼
+   ┌──────────┐  fetch ok + 3 required present   ┌──────────┐
+   │ LOADING  │──────────────────────────────────▶│ VERIFIED │  upload enabled
+   └──────────┘                                   └──────────┘
+        │
+        ├── 404 ─────────────▶ ┌───────────┐
+        ├── 403 ─────────────▶ │ NOT       │  upload withheld
+        │                      │ VERIFIED  │
+        ├── required field ───▶ └───────────┘
+        │   missing/null
+        │
+        └── network / 500 ───▶ ┌───────────┐
+                               │ UNAVAIL.  │  upload withheld + retry
+                               └───────────┘
+```
+
+## States
+
+### BROWSE — no `event_id` in the address
+
+Unchanged (FR-013). The events-needing-packets table renders exactly as today.
+Row and action-button links are simplified per D4 but target the same page.
+
+### LOADING — request in flight
+
+No identifying values shown, and **no upload control**. The form must not
+appear before the values it exists to be checked against.
+
+### VERIFIED — details retrieved, all three required identifiers present
+
+The only state that accepts a packet.
+
+| Field | Source | Empty rendering |
+|---|---|---|
+| Patient ID | `data.patient_id` | n/a — guaranteed present |
+| Site Patient ID | `data.site_patient_id` | n/a — guaranteed present |
+| Date | `data.event_date` (ISO) | n/a — guaranteed present |
+| Criteria | `data.criteria[]` as `name: value` pairs | `—` when `[]` (FR-006a) |
+
+Requirements met: FR-001, FR-002, FR-004, FR-005, FR-007, FR-008, FR-009,
+FR-012.
+
+- Patient ID and Site Patient ID carry **distinct labels** (FR-005). The page
+  must not collapse them into one line the way `EventScrub.jsx:78` does.
+- Criteria render as name-and-value pairs (FR-012), in response order, which
+  the backend has already sorted (FR-008). The component must not re-sort.
+- A criterion with an empty `value` shows its name with `—` in place of the
+  value.
+- Empty criteria never disable the upload control (FR-006b).
+
+### NOT VERIFIED — 404, 403, or a required identifier missing/null
+
+Message stating the event could not be verified. **No identifying fields
+rendered as empty** (FR-010) and **no upload control** (FR-011). A route back
+to the events list is offered.
+
+The three trigger conditions are deliberately collapsed into one user-facing
+state: all three mean the same thing to an uploader — the event on screen is
+not one they can check a packet against. The 403 wording follows however the
+rest of the app reports insufficient access.
+
+### UNAVAILABLE — network error or 500
+
+Message that details are temporarily unavailable, **no upload control**, plus a
+retry that re-issues the request in place. Success transitions to VERIFIED
+without the uploader leaving the page (FR-011a).
+
+## Invariants
+
+1. The upload control exists **only** in VERIFIED. No other state renders a
+   file input or submit button. (FR-011, SC-003a)
+2. `event_id` is the only query parameter read. `patient_id`, `date`, and
+   `criteria` are ignored if present in an old bookmark. (FR-003)
+3. No identifying field is ever rendered blank, absent, or as the string
+   `"undefined"` for an event that exists. (FR-006, SC-003)
+4. The rendered values depend only on `event_id`, never on the navigation
+   route taken. (FR-004, SC-002)
+
+## Link changes (D4)
+
+`patient_id`, `date`, and `criteria` are dropped from the constructed links;
+`event_id` remains.
+
+| Location | Current | After |
+|---|---|---|
+| `EventUpload.jsx:78` (row click) | `?event_id=…&patient_id=undefined&date=…&criteria=…` | `?event_id=…` |
+| `EventUpload.jsx:201` (action button) | `?event_id=…` | unchanged |
+| `EventReupload.jsx:68` (row click) | `?event_id=…&patient_id=undefined&date=…&criteria=…` | `?event_id=…` |
+
+All three converge on one URL shape, which is what makes SC-002 testable.

--- a/specs/008-upload-event-identifiers/data-model.md
+++ b/specs/008-upload-event-identifiers/data-model.md
@@ -1,0 +1,107 @@
+# Phase 1 Data Model: Populate event identifiers on the upload page
+
+**Feature**: `008-upload-event-identifiers`
+**Date**: 2026-08-13
+
+**No schema change.** No table, column, index, or constraint is added, altered,
+or dropped. No migration is required and nothing under `init/` changes. This
+feature reads data that already exists and is already populated. The model
+below documents the entities as they stand and the shape in which they are
+newly exposed.
+
+## Entities (existing, unchanged)
+
+### Event — `events`
+
+The clinical event a packet is uploaded for.
+
+| Field | Type | Notes for this feature |
+|---|---|---|
+| `id` | `int(11)` PK | The `event_id` in the page address |
+| `patient_id` | `int(11)` FK → `patients_view.id` | Displayed as **Patient ID**. Required at creation |
+| `event_date` | `date` | Displayed as **Date**. Required at creation |
+| `status` | enum | Not displayed; governs which list the event appears in |
+
+Serialized dates are emitted ISO-8601 (`YYYY-MM-DD`) by the existing
+comprehension in `get_event_details` (`flask_backend/table_service.py:934-937`),
+which satisfies FR-007 without further work.
+
+### Patient — `patients_view`
+
+Read-only view unioning `uw_patients2` with the FederatedX proxy of
+`cnics_data.Patient`. The application never writes to either half.
+
+| Field | Type | Notes for this feature |
+|---|---|---|
+| `id` | `int(11)` PK | Joined from `events.patient_id` |
+| `site_patient_id` | `varchar(64)` | Displayed as **Site Patient ID**. Required at creation |
+| `site` | `varchar` | Not displayed — out of scope per spec Assumptions |
+
+`create_event` (`table_service.py:941+`) rejects a create whose
+`site_patient_id` or `site` is blank and requires the patient to already exist
+in the view. This is the upstream enforcement the spec relies on when treating
+these identifiers as guaranteed present.
+
+The join is a `LEFT JOIN` (`table_service.py:914`), so an event whose patient
+row cannot be resolved yields `NULL` for `site_patient_id`. Per FR-006 that is
+an anomaly, not an ordinary empty value, and routes to the verification-failure
+path rather than to a placeholder.
+
+### Criterion — `criterias`
+
+| Field | Type | Notes for this feature |
+|---|---|---|
+| `id` | `int(11)` PK | Secondary sort key, for determinism among equal names |
+| `event_id` | `int(11)` FK → `events.id` | Indexed (`KEY event_id`) |
+| `name` | `varchar(50)` NOT NULL | Displayed |
+| `value` | `varchar(100)` NOT NULL | Displayed — **new**; no existing surface exposes it |
+
+Cardinality is zero-or-more per event. Zero is a legitimate state (spec
+Assumptions, FR-006b) and must not block upload.
+
+Both columns are `NOT NULL` at the schema level, so a criterion with a name but
+no value is not expected. The spec's edge case for it is defended in the view
+layer only, as free text may be the empty string.
+
+## Newly exposed shape
+
+`get_event_details(event_id)` gains one key. Every existing key is unchanged;
+this is additive, so `EventScrub` and `EventScreen` are unaffected.
+
+```text
+{
+  ...existing keys (id, patient_id, site_patient_id, site, status,
+     event_date, add_date, upload_date, ..., *_username)...,
+  "criteria": [ { "name": str, "value": str }, ... ]   # NEW, [] when none
+}
+```
+
+**Ordering**: `ORDER BY name, id`. The `name` sort matches the
+`GROUP_CONCAT(c.name ORDER BY c.name ...)` already used by the list queries
+(`table_service.py:154`), so the upload page presents criteria in the same
+sequence as the events lists. The `id` tiebreak makes the order total, so it
+cannot vary between loads when two criteria share a name — FR-008's stability
+requirement.
+
+**Empty case**: an event with no criteria yields `[]`, never `null`. A single
+representation for "none" keeps the consuming component from branching on two
+falsy shapes.
+
+## Validation rules derived from requirements
+
+| Rule | Source | Enforced where |
+|---|---|---|
+| Patient ID, Site Patient ID, and event date are present for any retrievable event | FR-006 | Upstream at `create_event`; the view treats absence as verification failure, not as a value to render |
+| Absence of any required identifier blocks packet submission | FR-011 | Frontend gate on the upload form |
+| Absence of criteria never blocks packet submission | FR-006b | Frontend gate excludes `criteria` from its condition |
+| Criteria order is stable across loads | FR-008 | `ORDER BY name, id` in the query |
+| Each criterion shows name and value | FR-008, FR-012 | Structured pairs in the response; rendered as pairs |
+| Event date format matches the rest of the app | FR-007 | Existing ISO serialization in `get_event_details` |
+| URL-borne identifier values are ignored | FR-003 | Frontend reads only `event_id` from the address |
+
+## State transitions
+
+None. This feature performs no write and does not advance the event lifecycle.
+The packet upload itself (`POST /api/events/<id>/upload_raw`) continues to move
+an event to `uploaded` exactly as it does today; the only change is that the
+control which triggers it is withheld until the event has been verified.

--- a/specs/008-upload-event-identifiers/plan.md
+++ b/specs/008-upload-event-identifiers/plan.md
@@ -1,0 +1,172 @@
+# Implementation Plan: Populate event identifiers on the upload page
+
+**Branch**: `008-upload-event-identifiers` | **Date**: 2026-08-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/008-upload-event-identifiers/spec.md`
+
+## Summary
+
+The packet-upload page shows Patient ID, Date, and Criteria as blank, and does
+not show Site Patient ID at all, because it reads those values from the query
+string rather than from the event record. The most-used entry point — the
+"upload" action button — passes only `event_id`, and Patient ID is broken on
+every route because neither list query returns the column the link is built
+from.
+
+The fix is to source all four values from the stored record via the existing
+`GET /api/events/{id}` endpoint, which already returns three of them. Only
+criteria needs backend work: it is absent from that endpoint, and the list
+queries that do expose it flatten names via `GROUP_CONCAT` and discard values,
+which the clarified name-and-value requirement rules out. The endpoint gains a
+structured `criteria` array; the page fetches on mount and renders from the
+response, ignoring URL-borne values entirely.
+
+Because the three required identifiers are enforced upstream at event creation,
+their absence can only mean the event could not be verified — so the upload
+control is withheld unless all three are present. Criteria are optional and
+never gate the upload.
+
+No schema change, no migration, no new dependency.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (Flask backend); JavaScript / JSX, React 19 (frontend)
+**Primary Dependencies**: Flask, SQLAlchemy, mysql-connector-python; React 19, react-router-dom 6, Vite 7 — **no new dependency**
+**Storage**: MariaDB 10.11, shared schema under `init/`. **No schema change in this feature** — all four values already exist and are populated
+**Testing**: pytest (`flask_backend/tests/`, 10 modules). **No frontend test infrastructure exists**; page states are verified manually per quickstart.md (research D6)
+**Target Platform**: Linux server, Docker Compose stack
+**Project Type**: Web application — Flask backend + React SPA frontend
+**Performance Goals**: One additional indexed single-event query per upload-page load (`criterias` is indexed on `event_id`). Identifiers visible no later than the rest of the page becomes usable (SC-005)
+**Constraints**: Additive API change only — `EventScrub` and `EventScreen` consume the same endpoint and must be unaffected. `openapi.json` must be regenerated in the same PR
+**Scale/Scope**: 2 backend files, 2 frontend files, 1 test module, 1 regenerated contract. Single shared page; no study-specific behavior
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against constitution v1.4.0.
+
+| Principle | Status | Assessment |
+|---|---|---|
+| **I. Single Codebase, Many Studies** | ✅ PASS | Changes land in shared `pages/` and shared backend modules. The VTE copies under `frontend/src/studies/vte/` are explicitly out of scope — the fork is not extended, consistent with Principle I's ban on divergent copies |
+| **II. Study Data Isolation** | ✅ PASS | No cross-study access. Reads one event by id within the deployment's own database. No change to DB users, scopes, or storage paths |
+| **III. Backwards Compatibility With Legacy Data** | ✅ PASS | Not engaged. No schema change, no migration, no change to the event lifecycle, role model, or the `patients_view` shape. The API change is to this app's own route, not a legacy contract, and is purely additive |
+| **IV. Configuration Over Code Forks** | ✅ PASS | No new flag, no `STUDY_TYPE` branch, no study-specific `if/elif`. The four fields are study-agnostic |
+| **V. Workflow and Role Parity** | ✅ PASS | No state added, removed, renamed, or bypassed. The event lifecycle is untouched — this feature performs no write. Withholding the upload control is a view-layer guard, not a state-machine change; an event's eligibility to be uploaded is unchanged |
+| **VI. Pre-Release Iteration and Discovery** | ✅ PASS | Current behavior recorded before modification in research.md, including the exact `undefined` interpolation and the per-route breakdown. The now-dead query parameters are removed rather than left silently in place (research D4), per the unused-subsystem rule |
+
+**Security & Data Governance**
+
+| Rule | Status | Assessment |
+|---|---|---|
+| PHI handling | ✅ PASS | No new logging. Patient identifiers are rendered to an authorized uploader in the browser, not logged. No secrets involved |
+| Authorization | ⚠️ PASS with documented finding | No new endpoint is created, so the "declare roles at definition time" rule is not triggered. However `GET /api/events/<id>` carries `@requires_auth` with **no role decorator** (`app.py:614-616`), unlike `need_packets` and `upload_raw` which scope non-admins by site. This feature neither creates nor widens the gap, but surfaces patient identifiers on one more page. Recorded in research D5 and quickstart as a follow-up; deliberately not changed here because it would alter behavior for `EventScrub` and `EventScreen`, which this feature does not otherwise touch |
+| File storage | ✅ PASS | No change to `FILES_DIR` / `DOWNLOADS_DIR` handling |
+
+**Development Workflow & Quality Gates**
+
+| Gate | Status | Assessment |
+|---|---|---|
+| Change review — which studies affected | ✅ PASS | **Shared code, all studies.** The blast radius is `GET /api/events/<id>`'s response shape; the additive-only change keeps `EventScrub` and `EventScreen` working under every `STUDY_TYPE` |
+| Schema changes | ✅ N/A | None |
+| API contracts | ✅ PASS | `openapi.json` regenerated in the same PR — tracked as an explicit task, not left to CI |
+| Testing discipline | ✅ PASS | No new endpoint, so no new role-decorator test is required. Backend coverage added for the changed service function, which has none today |
+| Local development parity | ✅ PASS | Nothing added that works outside the compose stack |
+| Feature-flag discipline | ✅ N/A | No flag introduced |
+| Unused subsystem hygiene | ✅ PASS | Dead query parameters removed rather than retained (research D4) |
+
+**Result**: PASS. No violation requiring justification; Complexity Tracking is
+therefore omitted. One pre-existing authorization finding is documented and
+routed to a follow-up rather than silently inherited or opportunistically
+patched.
+
+### Post-design re-check (after Phase 1)
+
+Re-evaluated against the completed design artifacts. **Still PASS**, with two
+things the design work confirmed rather than changed:
+
+- The `criteria` addition is strictly additive (contracts/event-details.md), so
+  the Principle III and cross-study blast-radius assessments hold as written —
+  `EventScrub` and `EventScreen` ignore the new key and are unaffected.
+- The state machine in contracts/upload-page-ui.md withholds the upload control
+  in the view layer only. It sets no status, writes nothing, and does not change
+  which events are eligible for upload, so Principle V's ban on redefining or
+  bypassing lifecycle states remains untouched. Worth stating explicitly because
+  "block the upload" could otherwise be read as a workflow change.
+
+No new dependency, flag, endpoint, table, or study-specific branch was
+introduced during design, so no gate assessed above changes status.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-upload-event-identifiers/
+├── plan.md                       # This file
+├── spec.md                       # Feature specification
+├── research.md                   # Phase 0 — observed behavior + decisions D1–D6
+├── data-model.md                 # Phase 1 — entities (no schema change)
+├── quickstart.md                 # Phase 1 — files, data flow, verification
+├── contracts/
+│   ├── event-details.md          # Phase 1 — GET /api/events/{id} additive change
+│   └── upload-page-ui.md         # Phase 1 — page state machine and invariants
+├── checklists/
+│   └── requirements.md           # Spec quality checklist — all items pass
+└── tasks.md                      # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+flask_backend/
+├── app.py                        # EDIT — docstring only, route 614 (OpenAPI source)
+├── table_service.py              # EDIT — get_event_details (~874): add criteria query
+└── tests/
+    └── test_table_service.py     # EDIT — new coverage for the criteria key
+
+frontend/src/
+└── pages/
+    ├── EventUpload.jsx           # EDIT — fetch on mount, 4 states, gate form, link
+    └── EventReupload.jsx         # EDIT — simplify row link (line 68)
+
+openapi.json                      # REGENERATE — python -m flask_backend.generate_openapi
+```
+
+**Structure Decision**: Web application layout, matching the repository's
+existing split — Flask backend in `flask_backend/`, React SPA in
+`frontend/src/`, backend tests colocated in `flask_backend/tests/`. This
+feature adds no directory and no file; every change is an edit to an existing
+one plus a regenerated artifact.
+
+Explicitly **not** in the tree above: anything under
+`frontend/src/studies/vte/` (fork not extended, per spec Assumptions and
+Principle I) and anything under `init/` (no schema change).
+
+## Phase 2 notes for `/speckit.tasks`
+
+Suggested sequencing, backend before frontend so the page has a real response
+to render against:
+
+1. **Backend criteria query** — `get_event_details` returns
+   `criteria: [{name, value}]` ordered by `name, id`, `[]` when none. Verify
+   the existing keys are untouched so the two sibling pages keep working.
+2. **Backend tests** — event with several criteria (order, both fields), event
+   with none (`[]` not `null`), and a regression assertion that the pre-existing
+   keys still serialize as before.
+3. **Docstring + `openapi.json`** — document the new key, regenerate, commit
+   the delta.
+4. **Frontend fetch and render** — replace the three `searchParams` reads with
+   a fetch of `/api/events/<event_id>`; render the four values with Patient ID
+   and Site Patient ID distinctly labelled; criteria as `name: value` pairs in
+   response order without re-sorting.
+5. **Frontend state gating** — the four states from
+   `contracts/upload-page-ui.md`; the upload control exists only in VERIFIED;
+   retry available in UNAVAILABLE.
+6. **Link cleanup** — `EventUpload.jsx:78` and `EventReupload.jsx:68` carry
+   `event_id` only; confirm old bookmarks with the extra parameters still work.
+7. **Manual verification** — the four routes and four edge cases in
+   quickstart.md.
+
+Story mapping: tasks 1–4 deliver User Story 1 (P1); task 6 with 4 completes
+User Story 2 (P1); task 5 delivers User Story 3 (P2) and is independently
+testable once 4 is in place.

--- a/specs/008-upload-event-identifiers/quickstart.md
+++ b/specs/008-upload-event-identifiers/quickstart.md
@@ -1,0 +1,119 @@
+# Quickstart: Populate event identifiers on the upload page
+
+## What this feature does
+
+`/events/upload?event_id=[n]` shows the event's **Patient ID**, **Site Patient
+ID**, **Date**, and **Criteria** so an uploader can cross-reference them
+against the packet in hand before attaching it. Today those fields are blank
+because the page reads them from the URL instead of from the event record; the
+"upload" action button and any bookmarked URL carry none of them, and Patient
+ID is broken on every route.
+
+The page now fetches the event and renders from the record. If it cannot, it
+says so and withholds the upload control rather than showing an unverifiable
+form.
+
+## Files involved
+
+**Backend**
+
+- `flask_backend/table_service.py` — **edit** `get_event_details` (~line 874):
+  add a second indexed query against `criterias` and return
+  `criteria: [{name, value}]`, ordered by `name` then `id`. `[]` when none.
+  All other keys unchanged.
+- `flask_backend/app.py` — **edit** the docstring of `get_event_details`
+  (line 614) to document the new key for the OpenAPI generator. No decorator
+  change.
+- `openapi.json` — **regenerate**, do not hand-edit.
+
+**Frontend**
+
+- `frontend/src/pages/EventUpload.jsx` — **edit**: fetch
+  `/api/events/<event_id>` on mount (mirror `EventScrub.jsx:15-24`); render
+  the four values from the response; drop the `patient_id` / `date` /
+  `criteria` reads at lines 120-123; add the four UI states; gate the upload
+  form on VERIFIED; simplify the row link at line 78.
+- `frontend/src/pages/EventReupload.jsx` — **edit**: simplify the row link at
+  line 68 to carry `event_id` only.
+
+**Tests**
+
+- `flask_backend/tests/test_table_service.py` — **add** coverage for the new
+  `criteria` key. `get_event_details` has none today.
+
+**Not touched**: `init/` (no schema change, no migration), any file under
+`frontend/src/studies/vte/`, and the authorization on
+`GET /api/events/<id>` (see the follow-up note below).
+
+## Data flow
+
+```text
+URL ?event_id=n
+   └─▶ GET /api/events/n
+          ├─ events.patient_id                    ──▶ Patient ID
+          ├─ patients_view.site_patient_id        ──▶ Site Patient ID
+          ├─ events.event_date  (ISO)             ──▶ Date
+          └─ criterias[] {name, value}  (NEW)     ──▶ Criteria
+```
+
+Three of the four already come back from this endpoint. Criteria is the only
+gap: `get_event_details` doesn't select it, and the list queries that do use
+`GROUP_CONCAT(c.name …)` — names only, values discarded.
+
+## The four states
+
+| State | When | Upload control |
+|---|---|---|
+| LOADING | request in flight | withheld |
+| VERIFIED | 200 + all three required identifiers present | **enabled** |
+| NOT VERIFIED | 404, 403, or a required identifier null | withheld |
+| UNAVAILABLE | network error or 500 | withheld, with retry |
+
+The three required identifiers are mandatory upstream at event creation, so
+their absence means the event couldn't be verified — not that a field is
+merely empty. **Criteria are optional and must never gate the upload.**
+
+## Verify
+
+Run the backend suite:
+
+```bash
+python -m pytest flask_backend/tests/test_table_service.py -v
+```
+
+Regenerate the contract (must land in the same PR):
+
+```bash
+python -m flask_backend.generate_openapi
+```
+
+Then, against the compose stack, walk the routes for one known event id — all
+four must show identical values (SC-002):
+
+1. Events-needing-packets list → press the **"upload"** action button.
+   *This is the route from the bug report; it previously showed everything blank.*
+2. Same list → click the **row body** rather than the button.
+   *Patient ID previously rendered as `undefined` here.*
+3. Reupload list → click a row through to the upload page.
+4. Paste `/events/upload?event_id=[n]` directly into the address bar.
+
+Then check the edges:
+
+- An event with **no criteria** → criteria shows `—`, and the upload control is
+  still enabled.
+- An event with **several criteria** → each shows `name: value`, same order as
+  the `Criteria` column on the events list.
+- A **nonexistent** event id → message shown, no blank fields, no upload
+  control.
+- An **old bookmark** carrying `&patient_id=undefined&date=…&criteria=…` →
+  the extra parameters are ignored and correct values render from the record.
+
+## Follow-up raised, not fixed here
+
+`GET /api/events/<id>` carries `@requires_auth` with **no role decorator**
+(`flask_backend/app.py:614-616`), so any authenticated user can read any
+event's patient identifiers regardless of site — unlike `need_packets` and
+`upload_raw`, which both scope non-admins to their own site. This feature
+neither creates nor widens that gap, but it does surface those identifiers on
+one more page. Tightening it would change behavior for `EventScrub` and
+`EventScreen`, so it belongs in its own reviewed change. See research.md D5.

--- a/specs/008-upload-event-identifiers/research.md
+++ b/specs/008-upload-event-identifiers/research.md
@@ -1,0 +1,236 @@
+# Phase 0 Research: Populate event identifiers on the upload page
+
+**Feature**: `008-upload-event-identifiers`
+**Date**: 2026-08-13
+
+This document records the current observed behavior before modification, as
+required by Constitution Principle VI, and resolves the technical unknowns
+carried into planning.
+
+## Observed current behavior (pre-change)
+
+Recorded here because Principle VI prohibits changing code whose behavior has
+not first been documented.
+
+### The upload page reads its identifiers from the address bar
+
+`frontend/src/pages/EventUpload.jsx:120-123` resolves four values from the
+query string, not from any request:
+
+```js
+const eventId = searchParams.get('event_id')
+const patientId = searchParams.get('patient_id')
+const date = searchParams.get('date')
+const criteria = searchParams.get('criteria')
+```
+
+`EventUpload.jsx:211-218` renders them directly into the info box. The page
+issues no request for event details at any point; the only fetch it performs is
+the packet `POST` to `/api/events/<id>/upload_raw` (`EventUpload.jsx:164`).
+
+### There are four ways in, and none of them work fully
+
+| Entry route | Source | `patient_id` | `date` | `criteria` |
+|---|---|---|---|---|
+| "upload" action button | `EventUpload.jsx:201` | absent | absent | absent |
+| Row click, needs-packets list | `EventUpload.jsx:78` | `undefined` | present | present |
+| Row click, reupload list | `EventReupload.jsx:68` | `undefined` | present | present |
+| Bookmark / pasted URL | user | absent | absent | absent |
+
+The action button — the most prominent control on the row and the likeliest
+path for an uploader — navigates with `event_id` alone, which is exactly the
+URL shape in the bug report.
+
+The row-click paths look better but are not. They build the link from
+`row['Patient ID']`, and neither list query selects a column by that name:
+`get_events_need_packets` (`flask_backend/table_service.py:148-161`) and the
+reupload query (`table_service.py:401-407`) both select `ID`, `Date`,
+`Created`, `Uploaded`, `Scrubbed`, `Criteria`, `Site`. `row['Patient ID']` is
+therefore always `undefined`, and the string `"undefined"` is interpolated into
+the URL and rendered on the page. **Patient ID is broken on every route, not
+only on direct URLs.**
+
+### Site Patient ID is not displayed anywhere on this page
+
+No reference to `site_patient_id` exists in `EventUpload.jsx`. Comparable pages
+do show it — `EventScrub.jsx:78` and `EventScreen.jsx:58` both render
+`details.site_patient_id || details.patient_id || '—'` under a single
+"Patient ID" label.
+
+### The data itself is intact
+
+Nothing needs backfilling. Per the spec's clarified data model, the internal
+Patient ID, Site Patient ID, and event date are mandatory before an event can
+be created; `create_event` (`table_service.py:941+`) enforces
+`site_patient_id` and `site` and resolves the patient against `patients_view`
+before inserting. The blank fields are purely a failure to request data that
+already exists.
+
+## Decisions
+
+### D1: Source the identifiers from the existing event-details endpoint
+
+**Decision**: `EventUpload.jsx` fetches `GET /api/events/<event_id>` on mount
+and renders from the response, mirroring `EventScrub.jsx:15-24`.
+
+**Rationale**: The endpoint already exists (`flask_backend/app.py:614`, backed
+by `table_service.get_event_details` at `table_service.py:874`) and already
+returns `patient_id`, `site_patient_id`, `site`, and `event_date`. Three of the
+four required values need no backend work at all. Two sibling pages already
+consume this endpoint for the same purpose, so the upload page becomes
+consistent with them rather than novel.
+
+**Alternatives considered**:
+
+- *Add `Patient ID` and `Site Patient ID` columns to the list queries and keep
+  passing everything through the URL.* Rejected: it cannot fix the action
+  button or the bookmark route without threading params through every future
+  link, and FR-003 explicitly requires the stored record to be the source. It
+  also leaves the display vulnerable to stale links (spec edge case).
+- *A new purpose-built endpoint for the upload page.* Rejected: it would
+  duplicate an endpoint that already returns three of the four fields, against
+  Principle I's consolidation intent, and would need its own role decorators
+  and OpenAPI entry for no gain.
+
+### D2: Return criteria as structured name/value pairs from the details endpoint
+
+**Decision**: Extend `get_event_details` to include a `criteria` key holding a
+list of `{"name": str, "value": str}` objects, ordered by `name` then `id`.
+Fetch it with a second query against `criterias` rather than joining.
+
+**Rationale**: This is the only genuine gap. `get_event_details` does not
+select criteria at all, and the list queries that do
+(`table_service.py:154`) use `GROUP_CONCAT(c.name ...)` — names only, already
+flattened to a string, values discarded. FR-008 and FR-012 require both name
+and value, so neither existing source suffices.
+
+A separate query is used because joining `criterias` into the existing
+single-row query would multiply the row by the criteria count and force either
+a `GROUP_CONCAT` (which cannot carry structured pairs safely — names and values
+are free text and could contain the separator) or client-side de-duplication of
+every other column. The `criterias` table is indexed on `event_id`
+(`init/02-schema.sql:32`), so the extra lookup is a single indexed read.
+
+Ordering by `name` then `id` satisfies FR-008's stable-order requirement and
+matches the `ORDER BY c.name` already used by the list queries, so the upload
+page lists criteria in the same sequence as the events lists.
+
+**Alternatives considered**:
+
+- *`GROUP_CONCAT` with a delimiter pair.* Rejected: `name` is `varchar(50)` and
+  `value` is `varchar(100)`, both free text with no delimiter guarantee.
+  Parsing that back apart on the client is fragile and would corrupt any
+  criterion containing the chosen separator.
+- *A separate `/api/events/<id>/criteria` endpoint.* Rejected: it doubles the
+  round trips for one page and splits a single logical read of "everything that
+  identifies this event" across two contracts.
+
+### D3: Gate the upload form on successful verification
+
+**Decision**: Render the file input and submit control only when the details
+request has succeeded and all three required identifiers are present. Otherwise
+show a message and no upload control, with a retry affordance.
+
+**Rationale**: FR-011 requires it, and the clarified data model makes it
+unambiguous — the three identifiers exist for every real event, so their
+absence always means the event on screen could not be verified. Gating the
+form is what converts this feature from "show more information" into the actual
+guarantee the user asked for: no packet is attached to an unverified event.
+
+Criteria are deliberately excluded from the gate (FR-006b) because they are
+optional; an event with none is ordinary and must stay uploadable.
+
+**Alternatives considered**:
+
+- *Warn but allow upload.* Rejected against FR-011. It preserves the
+  wrong-packet risk in precisely the degraded state where it is most likely.
+- *Redirect to the events list on failure.* Rejected: it discards the URL the
+  uploader was working from and gives no way to retry (FR-011a).
+
+### D4: Retire the identifier query parameters rather than leaving them
+
+**Decision**: Remove the `patient_id`, `date`, and `criteria` parameters from
+the links constructed in `EventUpload.jsx:78` and `EventReupload.jsx:68`,
+leaving `event_id`. The page must tolerate their presence in old bookmarks by
+ignoring them.
+
+**Rationale**: Once the page sources everything from the stored record, these
+parameters are read by nothing. Principle VI forbids leaving silently dead code
+paths in the tree. Keeping them would also actively mislead — they are the
+mechanism that currently interpolates `"undefined"` into the address bar, and a
+future reader would reasonably assume they still drive the display.
+
+Ignoring rather than rejecting unknown parameters keeps existing bookmarks
+working, which the spec's stale-link edge case requires.
+
+**Alternatives considered**:
+
+- *Leave the parameters in place as a fallback when the fetch fails.* Rejected:
+  it directly contradicts FR-003 and would resurrect the stale-data edge case
+  the spec rules out, showing an uploader values that may no longer match the
+  record.
+
+### D5: Leave the endpoint's authorization unchanged, and document the gap
+
+**Decision**: No change to the decorators on `GET /api/events/<int:event_id>`.
+Record the observation and raise it as a follow-up outside this feature.
+
+**Rationale**: The endpoint carries `@requires_auth` only
+(`flask_backend/app.py:614-616`) — no role decorator — so any authenticated
+user can read any event's details, including patient identifiers, regardless of
+site. Every other event endpoint declares roles: `need_packets` is
+`@requires_any_role('reviewer', 'uploader', 'admin')` and additionally scopes
+non-admins to their own site (`app.py:455-484`), and `upload_raw` restricts
+uploaders to the event's site (`app.py:1372-1386`).
+
+This feature does not create the exposure and does not widen it — the upload
+page is reached only by users who already hold uploader or admin rights, and
+the endpoint is already consumed by `EventScrub` and `EventScreen`. But this
+change does put patient identifiers on one more page, so the gap is worth
+stating plainly rather than inheriting silently.
+
+Tightening it is deliberately out of scope: adding a role decorator or a
+site scope would change behavior for two pages this feature does not otherwise
+touch, and belongs in a change reviewed for that purpose under the
+constitution's "will this break any other study's deployment?" gate.
+
+**Alternatives considered**:
+
+- *Add `@requires_any_role('uploader', 'reviewer', 'admin')` in this PR.*
+  Rejected as scope creep with cross-page blast radius. Flagged as follow-up.
+
+### D6: Test at the backend layer; verify the frontend manually
+
+**Decision**: Add pytest coverage for the criteria addition to
+`get_event_details`. Verify the page states manually against the quickstart.
+
+**Rationale**: The repository has an established backend suite —
+`flask_backend/tests/` holds ten test modules including
+`test_table_service.py`, which is where `get_event_details` coverage belongs —
+and **no frontend test infrastructure at all** (no test runner, no `*.test.jsx`
+files anywhere under `frontend/`). Standing up a frontend harness to test one
+component's loading states is disproportionate to this change and would be a
+larger decision than the feature warrants.
+
+`get_event_details` currently has no direct test coverage, so the new tests are
+additive rather than modifications.
+
+**Alternatives considered**:
+
+- *Introduce Vitest and React Testing Library for the four page states.*
+  Rejected as out of scope. Worth proposing separately — the absence of any
+  frontend test harness is a real gap — but not as a side effect of a
+  display fix.
+
+## Resolved unknowns
+
+| Unknown | Resolution |
+|---|---|
+| Where do the four values come from? | `GET /api/events/<id>` for three; `criterias` table for the fourth (D1, D2) |
+| Does the details endpoint return criteria? | No. This is the only backend gap (D2) |
+| How are criteria stored? | `criterias(id, event_id, name varchar(50), value varchar(100))`, indexed on `event_id` (`init/02-schema.sql:26-35`) |
+| What loading/error pattern do sibling pages use? | `useEffect` + `fetch` + `res.ok` guard, `details` state defaulting to `null` (`EventScrub.jsx:15-24`) |
+| What placeholder convention exists? | `'—'` (em dash), per `EventScrub.jsx:78` and `EventScreen.jsx:58` |
+| Is there frontend test infrastructure? | No (D6) |
+| Does `openapi.json` need regenerating? | Yes — the response shape of an existing route changes. Constitution requires it land in the same PR |
+| Is a schema change needed? | No. All data exists; no migration, no `init/` change |

--- a/specs/008-upload-event-identifiers/spec.md
+++ b/specs/008-upload-event-identifiers/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Populate event identifiers on the upload page
+
+**Feature Branch**: `008-upload-event-identifiers`
+**Created**: 2026-08-13
+**Status**: Draft
+**Input**: User description: "At /events/upload?event_id=[n] these are all empty, but they should be populated: PatientID, Date, Criteria. The SitePatientID should be displayed here, too. All of the above items are needed so users can cross-reference fields to ensure that they upload the correct packet."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Uploader verifies the event before uploading a packet (Priority: P1)
+
+An uploader opens the packet-upload page for a specific event. Before selecting a file, they need to confirm that the event on screen is the same event the packet in front of them belongs to. The page shows the event's identifying details — internal Patient ID, Site Patient ID, event date, and the criteria that flagged the event — so the uploader can compare them against the packet's cover sheet and chart. Only after that comparison do they attach the file.
+
+**Why this priority**: This is the entire purpose of the request. Without these values the uploader is attaching a packet to an event they cannot verify, which risks associating a patient's chart with the wrong event — a data-integrity and privacy problem that is expensive to detect and correct downstream.
+
+**Independent Test**: Navigate directly to the upload page for a known event ID and confirm all four identifying values render with the correct data for that event, without having arrived from any particular list page.
+
+**Acceptance Scenarios**:
+
+1. **Given** an uploader opens the upload page for an event that exists, **When** the page finishes loading, **Then** the event's internal Patient ID, Site Patient ID, event date, and criteria are all displayed with values drawn from that event's stored record.
+2. **Given** an uploader opens the upload page for an event, **When** they compare the displayed Site Patient ID and event date to the packet in hand, **Then** the displayed values match the same event's values shown anywhere else in the application (event list, edit page, screening page).
+3. **Given** an event with no criteria recorded against it, **When** the page loads, **Then** the criteria field renders a neutral placeholder, the other three identifying values still display normally, and the uploader may proceed with the upload.
+4. **Given** an event with several criteria, **When** the page loads, **Then** each criterion is shown with both its name and its recorded value, so the uploader can check the measurement against the chart.
+
+---
+
+### User Story 2 - Identifiers are correct regardless of how the uploader arrived (Priority: P1)
+
+Uploaders reach the upload page several ways: by pressing the "upload" action button on a row in the events-needing-packets list, by clicking the row itself, by following a link from the reupload list, and by opening a bookmarked or pasted URL. The identifying details must be present and correct in every one of these cases.
+
+**Why this priority**: Same criticality as Story 1, and it is the reason the values are currently missing. The values today depend on what the originating link happened to carry, so the same event shows different information depending on the route taken to it. A verification aid that is only sometimes present cannot be relied upon, and an uploader who has learned to trust it is more at risk than one who never had it.
+
+**Independent Test**: Reach the upload page for the same event by each entry route in turn and confirm the four identifying values are identical and correct every time.
+
+**Acceptance Scenarios**:
+
+1. **Given** an uploader on the events-needing-packets list, **When** they press the "upload" action button on a row, **Then** the upload page shows that event's identifying details in full.
+2. **Given** an uploader on the events-needing-packets list, **When** they click the row body rather than the action button, **Then** the upload page shows the same identifying details as the action button produces.
+3. **Given** an uploader following a link from the reupload list, **When** the upload page opens, **Then** the identifying details are shown in full.
+4. **Given** an uploader who bookmarked or was sent an upload URL containing only the event identifier, **When** they open it, **Then** the identifying details are shown in full.
+5. **Given** two uploaders open the same event through two different routes, **When** both pages are loaded, **Then** both display the same values for all four fields.
+
+---
+
+### User Story 3 - The page behaves predictably when the event cannot be shown (Priority: P2)
+
+An uploader opens an upload URL whose event identifier does not correspond to an event they can see — it was mistyped, the event was removed, or their account lacks access. The page tells them plainly that the event could not be loaded, and does not offer to accept a file, instead of presenting an upload form with empty identifying fields.
+
+**Why this priority**: Lower frequency than the primary flow, but it protects the guarantee the feature exists to provide. An upload form showing blank identifiers is precisely the state this feature is meant to eliminate, and it must not reappear as an unhandled error case. Because the identifying values are guaranteed to exist for any real event, their absence always signals that the event on screen is not the event the uploader thinks it is.
+
+**Independent Test**: Open the upload page with a nonexistent event identifier and confirm the page states the problem, renders no empty identifying fields, and does not accept a file.
+
+**Acceptance Scenarios**:
+
+1. **Given** an upload URL naming an event that does not exist, **When** the page loads, **Then** the uploader sees a clear message that the event could not be found, and no identifying fields are shown as empty.
+2. **Given** an upload URL naming an event the user is not permitted to view, **When** the page loads, **Then** the uploader sees a message consistent with how the rest of the application reports insufficient access, and is not shown partial event data.
+3. **Given** the identifying details cannot be retrieved because of a temporary failure, **When** the page loads, **Then** the uploader is told the details are unavailable rather than being shown blank fields.
+4. **Given** any of the above states, **When** the uploader looks for a way to attach a packet, **Then** submitting a file is not available to them, so no packet can be attached to an event that could not be verified.
+5. **Given** a temporary failure that later clears, **When** the uploader retries, **Then** the identifying details display and the upload becomes available without further intervention.
+
+---
+
+### Edge Cases
+
+- An event has no criteria recorded at all — the criteria field shows a neutral placeholder, not an empty line. This is a legitimate state, because criteria are optional; it must not block the upload or be presented as an error.
+- An event has several criteria — all are shown with their values, in a stable and repeatable order, so two uploaders comparing the same event see the same text.
+- A criterion has a name but no recorded value — the name is still shown, with a neutral placeholder in place of the value.
+- A retrievable event is missing one of the three required identifying values — an anomaly, since all three are enforced upstream before an event can be created. The page treats this as a failure to verify the event rather than as an ordinary empty field, and does not accept a packet for it.
+- The upload URL carries stale identifying values left over from an older link while the stored record has since changed — the page displays the stored record's current values, never the values carried in the URL.
+- The upload URL carries identifying values that contradict the stored record — the stored record wins, with no silent merge of the two sources.
+- The event identifier is absent from the URL entirely — the page continues to present the list of events needing packets, as it does today.
+- An uploader leaves the page open for an extended period before submitting — the displayed identifiers remain those of the event named in the URL and do not silently change.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When the upload page is opened for a specific event, the system MUST display that event's internal Patient ID, Site Patient ID, event date, and criteria.
+- **FR-002**: The system MUST source all four displayed values from the event's stored record, identified solely by the event identifier in the address.
+- **FR-003**: The system MUST NOT depend on identifying values carried in the page address to populate the display; where such values are present they MUST be disregarded in favour of the stored record.
+- **FR-004**: The system MUST display the same values for a given event no matter which navigation route was used to reach the upload page.
+- **FR-005**: The system MUST label the internal Patient ID and the Site Patient ID distinctly, so an uploader can tell which identifier they are cross-referencing against the packet.
+- **FR-006**: The system MUST treat the internal Patient ID, Site Patient ID, and event date as always present for a retrievable event, since all three are required before an event can be created. Their absence MUST be handled as a failure to verify the event (FR-010) rather than as an ordinary empty field.
+- **FR-006a**: The system MUST render a neutral placeholder when an event has no criteria, and MUST NOT render an empty value, an absent label, or a placeholder derived from missing data such as "undefined".
+- **FR-006b**: The system MUST NOT prevent or discourage an upload solely because an event has no criteria recorded, as criteria are optional.
+- **FR-007**: The system MUST present the event date in the same format used elsewhere in the application for event dates, so values can be compared across pages without reinterpretation.
+- **FR-008**: The system MUST display every criterion recorded against the event as a name-and-value pair, in a stable order that does not vary between loads.
+- **FR-009**: The system MUST display the identifying details before the uploader can submit a file, so the cross-reference can be performed as part of the upload task rather than after it.
+- **FR-010**: When the named event cannot be retrieved — because it does not exist, is not accessible to the user, or retrieval failed — the system MUST tell the uploader that the event details are unavailable, and MUST NOT present the identifying fields as empty.
+- **FR-011**: The system MUST NOT accept a packet for an event whose identifying details could not be retrieved or displayed. Because the three required identifiers always exist for a real event, an inability to show them means the event cannot be verified, and no cross-reference is possible.
+- **FR-011a**: When a failure to retrieve the details is temporary, the system MUST allow the uploader to retry and MUST restore the upload capability once the details display, without requiring them to start over elsewhere.
+- **FR-012**: The system MUST show each criterion's recorded value alongside its name, so the uploader can cross-reference the measurement against the chart and not only the criterion's label.
+- **FR-013**: The system MUST keep the existing behaviour of the upload page when no event is named in the address — the list of events needing packets continues to be shown.
+
+### Key Entities *(include if data involved)*
+
+- **Event**: The clinical event a packet is being uploaded for. Identified by an event identifier that appears in the page address. Carries the event date, a link to the patient it belongs to, and its position in the review workflow. The event date is mandatory at creation.
+- **Patient**: The subject of the event. Carries two distinct identifiers relevant here — an internal identifier used to relate records within the application, and a Site Patient ID assigned by the clinical site, which is the identifier an uploader will find on the packet itself. Both are mandatory before an event can be created, so both are always available for a real event.
+- **Criterion**: An ascertainment rule that flagged the event for review. Each has a name and an associated value. Criteria are optional — an event may have none, one, or several — so their absence is a normal state rather than an error.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For any event reachable from the upload page, all four identifying values are populated from the stored record in 100% of page loads where the event exists and the user may view it.
+- **SC-002**: The four identifying values are identical across every navigation route into the upload page, verified for all four routes currently in use.
+- **SC-003**: Zero occurrences of a blank, absent, or "undefined" identifying field on an upload page for an event that exists.
+- **SC-003a**: Zero packets are accepted for an event whose identifying details were not displayed to the uploader.
+- **SC-003b**: Events with no criteria recorded remain fully uploadable — no measurable drop in upload completion for those events relative to events that have criteria.
+- **SC-004**: An uploader can complete the cross-reference between the on-screen details and the packet in hand without navigating away from the upload page.
+- **SC-005**: The identifying details are visible to the uploader within the time it takes the rest of the upload page to become usable, so verification adds no perceptible wait to the upload task.
+- **SC-006**: Packets attached to the wrong event, as reported through the existing rescrub and reject paths, decline relative to the rate recorded before this change.
+
+## Assumptions
+
+- The four values requested are those already recorded against the event and its patient; this feature displays existing data and introduces no new data collection.
+- "PatientID" in the request refers to the application's internal patient identifier, and "SitePatientID" to the clinical site's own identifier for the same patient. The request asks for both to be visible because they serve different cross-referencing purposes.
+- "Date" refers to the event date, the value labelled "Date" on the events lists — not the date the event record was created or the date of upload.
+- "Criteria" refers to the ascertainment criteria that flagged the event, the same set summarised in the "Criteria" column of the events lists. The upload page shows their values as well as their names, so it deliberately carries more detail than that column.
+- The internal Patient ID, Site Patient ID, and event date are mandatory upstream — an event cannot be created without them. The specification therefore treats them as guaranteed present for any retrievable event, and treats their absence as a verification failure rather than as missing-but-acceptable data.
+- Criteria are optional by contrast, so an event with none is ordinary and must remain uploadable.
+- The clinical site is not among the fields requested and is therefore out of scope, even though it is displayed on comparable pages elsewhere in the application.
+- The reupload list links to the upload page rather than duplicating it, so correcting the upload page covers uploaders arriving from reupload without separate work there.
+- The legacy VTE-specific copies of these pages are out of scope. Per standing project guidance the VTE fork is not to be extended, and new work targets the shared pages only.
+- Existing access rules for viewing an event are unchanged; this feature displays details only to users already entitled to see that event, and adds no new exposure of patient identifiers.
+- The neutral placeholder for absent criteria follows the convention already used on the screening and scrubbing pages, so the pages read consistently.
+- No change to how packets are stored, validated, or processed after upload is intended; the change is confined to what the uploader is shown before submitting.

--- a/specs/008-upload-event-identifiers/tasks.md
+++ b/specs/008-upload-event-identifiers/tasks.md
@@ -1,0 +1,241 @@
+---
+description: "Task list for 008-upload-event-identifiers"
+---
+
+# Tasks: Populate event identifiers on the upload page
+
+**Input**: Design documents from `/specs/008-upload-event-identifiers/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Backend test tasks are included. Not because TDD was requested, but
+because research D6 and the constitution's testing-discipline gate call for
+coverage of the changed service function, which has none today. There are no
+frontend test tasks — the repository has no frontend test infrastructure, and
+standing one up is explicitly out of scope (research D6).
+
+**Organization**: Tasks are grouped by user story so each can be implemented
+and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete work)
+- **[Story]**: Which user story the task serves (US1, US2, US3)
+
+## Path Conventions
+
+Web application layout, per plan.md: Flask backend in `flask_backend/`, React
+SPA in `frontend/src/`, backend tests in `flask_backend/tests/`. All paths below
+are repository-relative.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish the baseline. No project initialization is needed — this
+feature adds no file, directory, or dependency.
+
+- [ ] T001 Reproduce and record the current behavior on the running stack: open `/events/upload?event_id=[n]` via the "upload" action button and confirm Patient ID, Date, and Criteria are blank; open the same event by clicking a list row and confirm the address bar contains `patient_id=undefined`. Constitution Principle VI requires observed behavior be recorded before modification — capture both in the PR description (research.md already documents the code-level findings)
+- [X] T002 Confirm the backend suite is green before any change: run `python -m pytest flask_backend/tests/ -q` from the repository root, so later failures are attributable to this feature
+
+> **T001 blocked — needs a running stack.** No deployment is reachable from
+> this workstation. The code-level baseline is fully recorded in research.md
+> (the `searchParams` reads, the per-route table, and the `row['Patient ID']`
+> column that no list query returns), which satisfies the substance of
+> Principle VI. The browser observation still needs to be made by someone with
+> stack access before the PR is opened.
+
+**Checkpoint**: Suite green (82 passed), no dependency change needed. Baseline
+recorded at code level; browser confirmation outstanding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Expose criteria from the event-details endpoint. This is the only
+backend gap — `patient_id`, `site_patient_id`, and `event_date` already come
+back from `GET /api/events/{id}`. Every user story that renders criteria depends
+on this phase.
+
+**⚠️ CRITICAL**: No frontend story work can be verified against real data until
+T003 lands.
+
+- [X] T003 Extend `get_event_details` in `flask_backend/table_service.py` (~line 874) to return a `criteria` key: a list of `{"name": ..., "value": ...}` dicts read from the `criterias` table with a second query filtered on `event_id` and `ORDER BY name, id`. Return `[]` — never `None` — when the event has no criteria. Do not join `criterias` into the existing single-row query; that would multiply the row by the criteria count. Leave every existing key in the return dict untouched, including the ISO date serialization at lines 934-937
+- [X] T004 [P] Add tests to `flask_backend/tests/test_table_service.py` covering `get_event_details`: (a) an event with several criteria returns both `name` and `value` for each, ordered by name; (b) two criteria sharing a name order deterministically by `id`; (c) an event with no criteria returns `[]` and not `None`; (d) a regression assertion that `patient_id`, `site_patient_id`, `site`, and `event_date` still serialize exactly as before, so `EventScrub` and `EventScreen` are provably unaffected
+- [X] T005 [P] Update the docstring of `get_event_details` in `flask_backend/app.py` (route at line 614) to document the new `criteria` array in the Swagger response schema, following the docstring style used by `events_need_packets` at line 455. Do not change the decorators — the authorization gap is a documented follow-up, not part of this feature (research D5)
+- [X] T006 Regenerate the API contract by running `python -m flask_backend.generate_openapi` from the repository root and commit the resulting `openapi.json` delta. The constitution requires this land in the same PR as the route change. Do not hand-edit the file (depends on T005)
+
+**Checkpoint**: `GET /api/events/{id}` returns all four identifying values. The
+backend half of the feature is complete and independently verifiable with
+`curl` before any frontend work begins.
+
+---
+
+## Phase 3: User Story 1 - Uploader verifies the event before uploading (Priority: P1) 🎯 MVP
+
+**Goal**: The upload page shows Patient ID, Site Patient ID, Date, and Criteria
+for the named event, sourced from the stored record rather than the address bar.
+
+**Independent Test**: Open `/events/upload?event_id=[n]` directly for a known
+event and confirm all four values render correctly, having arrived from no
+particular list page.
+
+- [X] T007 [US1] In `frontend/src/pages/EventUpload.jsx`, add a `details` state and a `useEffect` that fetches `${API_BASE}/api/events/${eventId}` with `credentials: 'include'` when `eventId` is present, mirroring the pattern in `frontend/src/pages/EventScrub.jsx:15-24`. Guard on `res.ok` and store `json.data`. Do not fetch when no `event_id` is in the address — the browse list must keep working unchanged (FR-013)
+- [X] T008 [US1] In `frontend/src/pages/EventUpload.jsx`, delete the `patientId`, `date`, and `criteria` reads from `searchParams` at lines 121-123. Keep the `eventId` read at line 120 — it is the only parameter the page may consult (FR-003). Old bookmarks carrying the removed parameters must be ignored, not rejected
+- [X] T009 [US1] In the info box at `frontend/src/pages/EventUpload.jsx:211-218`, render Patient ID from `details.patient_id`, Site Patient ID from `details.site_patient_id`, and Date from `details.event_date`. Give Patient ID and Site Patient ID **distinct labels** on separate lines (FR-005) — do not collapse them into one line the way `EventScrub.jsx:78` does with `site_patient_id || patient_id`
+- [X] T010 [US1] In `frontend/src/pages/EventUpload.jsx`, render `details.criteria` as `name: value` pairs (FR-012), iterating the array in the order the response supplies. Do not re-sort on the client — ordering is already total and stable from T003 (FR-008)
+- [X] T011 [US1] In `frontend/src/pages/EventUpload.jsx`, render the em-dash placeholder `—` when `details.criteria` is empty, and when an individual criterion's `value` is an empty string, matching the convention at `EventScrub.jsx:78` and `EventScreen.jsx:58` (FR-006a). No identifying field may ever render blank, absent, or as the string `"undefined"`
+
+**Checkpoint**: Opening the upload page directly for an event shows all four
+values correctly. This is the MVP and resolves the reported bug for the direct
+and action-button routes.
+
+---
+
+## Phase 4: User Story 2 - Identifiers correct regardless of entry route (Priority: P1)
+
+**Goal**: All four entry routes converge on one URL shape and produce identical
+values.
+
+**Independent Test**: Reach the same event by the action button, both list row
+clicks, and a pasted URL; confirm the four values are identical every time.
+
+**Note**: Once T008 lands, the page already ignores URL-borne values, so route
+parity is largely achieved. This phase removes the now-dead parameters so the
+links stop asserting something the page no longer reads (research D4,
+Principle VI's unused-subsystem rule).
+
+- [X] T012 [P] [US2] In `frontend/src/pages/EventUpload.jsx`, simplify the `navigate()` call at line 78 to `/events/upload?event_id=${row['ID']}` — drop `patient_id`, `date`, and `criteria`. This also removes the source of the `patient_id=undefined` string, since `row['Patient ID']` is a column no list query returns
+- [X] T013 [P] [US2] In `frontend/src/pages/EventReupload.jsx`, apply the same simplification to the link at line 68, leaving `event_id` only
+- [ ] T014 [US2] Verify route parity for one known event id across all four entry points from `quickstart.md`: the "upload" action button (`EventUpload.jsx:201`), the needs-packets row body, the reupload list row, and a pasted URL. All four must display identical values (SC-002). Additionally open a legacy-shaped URL carrying `&patient_id=undefined&date=…&criteria=…` and confirm the extra parameters are ignored and correct values render from the record (depends on T012, T013)
+
+> **T014 blocked — needs a running stack.** Verified statically instead: no
+> reference to `patient_id`, `date`, or `criteria` query parameters remains in
+> either page, so all four routes now emit and read the same `?event_id=` shape,
+> and a legacy URL's extra parameters are simply never consulted. The
+> four-route walkthrough still needs to be performed against a deployment.
+
+**Checkpoint**: User Stories 1 and 2 both work. Every route into the page is
+correct, and no link constructs parameters the page does not read.
+
+---
+
+## Phase 5: User Story 3 - Predictable behavior when the event cannot be shown (Priority: P2)
+
+**Goal**: When the event cannot be verified, the page says so and does not offer
+to accept a packet.
+
+**Independent Test**: Open the page with a nonexistent event id and confirm a
+clear message, no empty identifying fields, and no upload control.
+
+**Design reference**: The four states and their invariants are specified in
+`contracts/upload-page-ui.md`.
+
+- [ ] T015 [US3] In `frontend/src/pages/EventUpload.jsx`, add explicit state tracking for the details request so the page can distinguish LOADING, VERIFIED, NOT VERIFIED, and UNAVAILABLE rather than inferring from a single nullable `details` value. Render no identifying values and no upload control while the request is in flight
+- [ ] T016 [US3] In `frontend/src/pages/EventUpload.jsx`, implement the NOT VERIFIED state for three conditions collapsed into one user-facing outcome: a 404, a 403, and a 200 whose `patient_id`, `site_patient_id`, or `event_date` is missing or null. All three mean the event could not be verified. Show a clear message plus a route back to the events list, render no identifying fields as empty (FR-010), and follow the app's existing convention for reporting insufficient access on the 403 case
+- [ ] T017 [US3] In `frontend/src/pages/EventUpload.jsx`, implement the UNAVAILABLE state for a network error or a 500: state that details are temporarily unavailable and offer a retry that re-issues the request in place. A successful retry must transition to VERIFIED without the uploader leaving the page (FR-011a)
+- [ ] T018 [US3] In `frontend/src/pages/EventUpload.jsx`, gate the packet form so the file input and submit control render **only** in the VERIFIED state (FR-011, SC-003a). Exclude `criteria` from the gate condition — criteria are optional, so an event with none must remain fully uploadable (FR-006b). The gate is a view-layer guard only: it must not set status, write anything, or change which events are eligible for upload (depends on T015, T016, T017)
+
+**Checkpoint**: All three user stories are independently functional. No packet
+can be attached to an event the uploader could not verify.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T019 [P] Walk the four edge cases from `quickstart.md` against the running stack: an event with no criteria (shows `—`, upload still enabled), an event with several criteria (`name: value` pairs, same order as the events list `Criteria` column), a nonexistent event id, and a legacy bookmark URL
+- [ ] T020 [P] Confirm the additive API change broke nothing: load `/events/scrub?event_id=[n]` and `/events/screen?event_id=[n]` and verify both still render their patient and date details as before. Both consume the same endpoint (`EventScrub.jsx:17`, `EventScreen.jsx`) and must ignore the new `criteria` key
+- [ ] T021 [P] Confirm no VTE file was modified: `git diff --name-only main | grep 'studies/vte'` must return nothing. The VTE fork is not extended by this feature (spec Assumptions, Principle I)
+- [ ] T022 Run the full backend suite `python -m pytest flask_backend/tests/ -q` from the repository root and confirm it is green, matching the T002 baseline plus the new tests
+- [ ] T023 Write the PR description with what the constitution's change-review gate requires: state that this touches **shared code affecting all studies**; answer "will this break any other study's deployment?" with the T020 and T004 evidence; include the T001 baseline observation per Principle VI; and record the pre-existing authorization finding on `GET /api/events/<id>` from research D5 as a tracked follow-up, not as something fixed here
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup — **blocks all user stories**, because criteria is one of the four values every story displays
+- **User Story 1 (Phase 3)**: Depends on Phase 2
+- **User Story 2 (Phase 4)**: Depends on Phase 3 — T008 is what makes route parity real; T012/T013 remove the dead parameters afterward
+- **User Story 3 (Phase 5)**: Depends on Phase 3 for the render path it gates. Independent of Phase 4
+- **Polish (Phase 6)**: Depends on all desired stories
+
+### Story Dependencies
+
+- **US1 (P1)**: The MVP. Depends only on Phase 2
+- **US2 (P1)**: Builds on US1's T008. Not independent of US1 — route parity is a property of sourcing from the record, which US1 establishes
+- **US3 (P2)**: Depends on US1's render path but is independent of US2. Can be worked in parallel with Phase 4 by a second developer
+
+### Within Each Story
+
+Most frontend tasks touch the single file `EventUpload.jsx` and are therefore
+sequential, not parallel. The `[P]` markers are concentrated in the backend
+phase and in polish, where tasks genuinely span different files.
+
+### Parallel Opportunities
+
+- **T004 and T005** — different files (`tests/test_table_service.py` vs `app.py`), both depend only on T003
+- **T012 and T013** — different files (`EventUpload.jsx` vs `EventReupload.jsx`)
+- **T019, T020, T021** — independent verification passes
+- **Phase 4 and Phase 5** — two developers can split them once Phase 3 is done
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# After T003 lands, these two are independent:
+Task: "Add get_event_details criteria tests in flask_backend/tests/test_table_service.py"
+Task: "Update get_event_details docstring in flask_backend/app.py"
+# T006 (openapi regeneration) must wait for the docstring task.
+```
+
+## Parallel Example: Phase 4
+
+```bash
+# Different files, no shared state:
+Task: "Simplify the row link at frontend/src/pages/EventUpload.jsx:78"
+Task: "Simplify the row link at frontend/src/pages/EventReupload.jsx:68"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phases 1–3)
+
+1. Phase 1 — record the baseline, confirm the suite is green
+2. Phase 2 — backend criteria; verify with `curl` before touching the frontend
+3. Phase 3 — the upload page renders from the record
+4. **STOP and VALIDATE**: open the page directly for a known event; all four
+   values populate
+
+This alone fixes the reported bug for the action-button and direct-URL routes,
+which are the routes in the report.
+
+### Incremental Delivery
+
+1. Phase 2 → backend verifiable standalone
+2. + Phase 3 → **MVP**, bug resolved for the primary routes
+3. + Phase 4 → all four routes converge; dead parameters gone
+4. + Phase 5 → verification guarantee enforced; no packet attaches to an
+   unverified event
+5. + Phase 6 → cross-page regression checks and PR gates
+
+### Suggested MVP Scope
+
+Phases 1–3 (T001–T011). Eleven tasks, of which four are backend and five are a
+single frontend file.
+
+---
+
+## Notes
+
+- `[P]` means different files with no incomplete dependency
+- Most of Phases 3 and 5 touch `frontend/src/pages/EventUpload.jsx`; sequence
+  them within the file rather than attempting parallel edits
+- No task touches `init/` — there is no schema change and no migration
+- No task touches `frontend/src/studies/vte/` — T021 asserts this
+- T006 must not be skipped or hand-edited; the regenerated contract is a
+  constitution gate, not a convenience


### PR DESCRIPTION
At /events/upload?event_id=[n] these are all empty, but they should be populated:
        PatientID
        Date
        Criteria
The SitePatientID should be displayed here, too.
All of the above items are needed so users can cross-reference fields to ensure that they upload the correct packet.