### PR TITLE
Adds .dockerignore files to flask_backend and frontend directories. Per

### DIFF
--- a/flask_backend/.dockerignore
+++ b/flask_backend/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.venv/
+venv/
+*.egg-info/
+.git/
+*.log
+.env*
+.DS_Store

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+build/
+coverage/
+.git/
+*.log
+.env*
+.DS_Store


### PR DESCRIPTION
Claude "Two .dockerignore files were missing and are now added: frontend/.dockerignore and flask_backend/.dockerignore. Worth knowing why the frontend one matters — frontend/Dockerfile does npm ci and then COPY . ., so with a populated host frontend/node_modules the build was copying host modules over the freshly installed ones. Pre-existing, unrelated to this feature, now fixed.".