### PR TITLE
After uploads, fix message to indicate next step in configured flow.

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -268,7 +268,7 @@ function App() {
           {/* Uploader routes (uploader or admin) */}
           <Route path="/events/upload" element={
             <ProtectedRoute requiredRoles={['uploader', 'admin']} auth={auth}>
-              <EventUpload studyType={studyType} configResolved={configResolved} />
+              <EventUpload studyType={studyType} configResolved={configResolved} workflow={workflow} />
             </ProtectedRoute>
           } />
           <Route path="/vte/upload" element={

--- a/frontend/src/pages/EventUpload.jsx
+++ b/frontend/src/pages/EventUpload.jsx
@@ -113,8 +113,20 @@ function TableWrapper({ endpoint, columns, renderActions, pageSize = PAGE_SIZE }
   )
 }
 
-function EventUpload({ studyType, configResolved = true }) {
+function EventUpload({ studyType, configResolved = true, workflow }) {
   const [searchParams] = useSearchParams()
+
+  // What happens to a packet after upload depends on which optional stages the
+  // deployment runs, so the confirmation names the stage the event actually
+  // enters next rather than assuming the full workflow (spec 003, FR-018 and
+  // FR-021). The `!== false` form matches EventViewAll: a missing, unresolved,
+  // or malformed control keeps the conservative full-workflow wording.
+  const wf = workflow || {}
+  const uploadSuccessMessage = wf.scrubbing !== false
+    ? 'Upload successful. Packet is now queued for scrubbing.'
+    : wf.screening !== false
+      ? 'Upload successful. Packet is now queued for screening.'
+      : 'Upload successful. Packet is now ready for assignment.'
 
   // Body content for the "Review packets should contain" box, chosen by the
   // deployment's study type. Resolved the same way as Home so both pages show
@@ -292,7 +304,7 @@ function EventUpload({ studyType, configResolved = true }) {
               )}
               {uploadStatus === 'success' && (
                 <div style={{ color: 'green', paddingTop: '6px' }}>
-                  Upload successful. Packet is now queued for scrubbing.
+                  {uploadSuccessMessage}
                 </div>
               )}
             </form>


### PR DESCRIPTION
After uploads, there was a hard-coded message that said that the next step is scrubbing. This change now looks at the configured workflow to determine what step to say is next (the problem was not in the flow itself, but in the message).